### PR TITLE
Make sure to mask when casting byte to short in receiveBytes()

### DIFF
--- a/src/main/java/javacard/framework/APDU.java
+++ b/src/main/java/javacard/framework/APDU.java
@@ -456,7 +456,7 @@ public final class APDU {
         if (Lc != 0) {
             short len = 0;
             if(buffer[ISO7816.OFFSET_LC] != 0) {
-                len = buffer[ISO7816.OFFSET_LC];
+                len = (short) (buffer[ISO7816.OFFSET_LC] & 0xff);
             }
             Lc -= len;
             ramVars[LC] = (byte) Lc;


### PR DESCRIPTION
fix an issue where lc > 0x80 the sign byte is promoted to the short len in receiveBytes()
