### PR TITLE
fix for Util.arrayCompare()

### DIFF
--- a/src/main/java/javacard/framework/Util.java
+++ b/src/main/java/javacard/framework/Util.java
@@ -200,7 +200,9 @@ public class Util {
         }
         for (short i = 0; i < length; i++) {
             if (src[srcOff + i] != dest[destOff + i]) {
-                return ((byte) (src[srcOff + i] >= dest[destOff + i] ? 1 : -1));
+                short thisSrc = (short) (src[srcOff + i] & 0x00ff);
+                short thisDest = (short) (dest[destOff + i] & 0x00ff);
+                return (byte) (thisSrc >= thisDest ? 1 : -1);
             }
         }
 

--- a/src/test/java/javacard/framework/UtilTest.java
+++ b/src/test/java/javacard/framework/UtilTest.java
@@ -1,0 +1,24 @@
+package javacard.framework;
+
+import junit.framework.TestCase;
+
+public class UtilTest extends TestCase {
+	/**
+	 * 
+	 */
+	public void testArrayCompare1() {
+		byte[] src = new byte[] {0x01};
+		byte[] dest = new byte[] {0x02};
+		byte res = Util.arrayCompare(src, (short)0, dest, (short)0, (short)1);
+		assertEquals(-1, res);
+	}
+	/**
+	 * 
+	 */
+	public void testArrayCompare2() {
+		byte[] src = new byte[] {(byte)0xff};
+		byte[] dest = new byte[] {0x01};
+		byte res = Util.arrayCompare(src, (short)0, dest, (short)0, (short)1);
+		assertEquals(1, res);
+	}
+}


### PR DESCRIPTION
failed comparisons where arrays contained values over 0x7f
fix this by up-casting to short and comparing, also add a small test
