### PR TITLE
Better SELECT handling and Applet deletion (amended)

### DIFF
--- a/src/main/java/com/licel/jcardsim/base/ApduCase.java
+++ b/src/main/java/com/licel/jcardsim/base/ApduCase.java
@@ -7,7 +7,7 @@ public enum ApduCase {
     Case1(false),
     Case2(false), Case2Extended(true),
     Case3(false), Case3Extended(true),
-    Case4(false), Case4Extended(true), CaseUnkown(false), Unkown(false);
+    Case4(false), Case4Extended(true);
 
     private final boolean extended;
 

--- a/src/main/java/com/licel/jcardsim/base/CardManager.java
+++ b/src/main/java/com/licel/jcardsim/base/CardManager.java
@@ -29,23 +29,7 @@ public class CardManager {
     // basic impl
     public static byte[] dispatchApdu(JavaCardInterface sim, byte[] capdu) {
         byte[] theSW = new byte[2];
-        // handles select applet command
-        if (capdu[ISO7816.OFFSET_CLA] == ISO7816.CLA_ISO7816
-                && capdu[ISO7816.OFFSET_INS] == ISO7816.INS_SELECT) {
-            byte[] appletSelectionResult = null;
-            try {
-                AID aid = new AID(capdu, ISO7816.OFFSET_CDATA, capdu[ISO7816.OFFSET_LC]);
-                appletSelectionResult = sim.selectAppletWithResult(aid);
-            } catch (Throwable t) {
-            }
-            if (appletSelectionResult == null) {
-                Util.setShort(theSW, (short) 0, ISO7816.SW_APPLET_SELECT_FAILED);
-                return theSW;
-            } else {
-                return appletSelectionResult;
-            }
-        
-        } else if (capdu[ISO7816.OFFSET_CLA] == (byte)0x80 && capdu[ISO7816.OFFSET_INS] == (byte)0xb8) {
+        if (capdu[ISO7816.OFFSET_CLA] == (byte)0x80 && capdu[ISO7816.OFFSET_INS] == (byte)0xb8) {
             // handle CREATE APPLTE command
             // command format:
             // CLA    INS  P0    P1

--- a/src/main/java/com/licel/jcardsim/base/Simulator.java
+++ b/src/main/java/com/licel/jcardsim/base/Simulator.java
@@ -203,6 +203,14 @@ public class Simulator implements JavaCardInterface {
         return createApplet(aid, bArray, bOffset, bLength);
     }
 
+    /**
+     * Delete an applet
+     * @param aid applet aid
+     */
+    public void deleteApplet(AID aid) {
+        SimulatorSystem.getRuntime().deleteApplet(aid);
+    }
+
     public boolean selectApplet(AID aid) throws SystemException {
     	byte[] resp = SimulatorSystem.selectAppletWithResult(aid);
     	if(resp != null && resp.length > 1) {

--- a/src/main/java/com/licel/jcardsim/base/SimulatorRuntime.java
+++ b/src/main/java/com/licel/jcardsim/base/SimulatorRuntime.java
@@ -15,13 +15,12 @@
  */
 package com.licel.jcardsim.base;
 
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Iterator;
+import com.licel.jcardsim.utils.AIDUtil;
 import javacard.framework.*;
 import javacardx.apdu.ExtendedLength;
+
+import java.lang.reflect.Method;
+import java.util.*;
 
 /**
  * Base implementation of Java Card Runtime
@@ -31,20 +30,20 @@ import javacardx.apdu.ExtendedLength;
 public class SimulatorRuntime {
 
     // storage for registered applets
-    private final HashMap applets = new HashMap();
+    private final SortedMap<AID, AppletHolder> applets = new TreeMap<AID, AppletHolder>(AIDUtil.comparator());
+    // method for resetting APDUs
     private final Method apduPrivateResetMethod;
+    // outbound response byte array buffer
+    private final byte[] responseBuffer = SimulatorSystem.makeInternalBuffer(Short.MAX_VALUE + 2);
+
     // current selected applet
     private AID currentAID;
     // previous selected applet
     private AID previousAID;
     // applet in INSTALL phase
     private AID appletToInstallAID;
-    // outbound response byte array buffer
-    final byte[] responseBuffer = SimulatorSystem.makeInternalBuffer(Short.MAX_VALUE + 2);
     // outbound response byte array buffer size
-    short responseBufferSize = 0;
-    // SW
-    final byte[] theSW = SimulatorSystem.makeInternalBuffer(2);
+    private short responseBufferSize = 0;
     // if the applet is currently being selected
     private boolean selecting = false;
 
@@ -69,9 +68,7 @@ public class SimulatorRuntime {
      */
     public AID lookupAID(byte buffer[], short offset, byte length) {
         // no construct new AID, iterate applets
-        Iterator aids = applets.keySet().iterator();
-        while (aids.hasNext()) {
-            AID aid = (AID) aids.next();
+        for (AID aid : applets.keySet()) {
             if (aid.equals(buffer, offset, length)) {
                 return aid;
             }
@@ -83,11 +80,9 @@ public class SimulatorRuntime {
      * Lookup applet by aid
      */
     public AppletHolder lookupApplet(AID lookupAid) {
-        Iterator aids = applets.keySet().iterator();
-        while (aids.hasNext()) {
-            AID aid = (AID) aids.next();
+        for (AID aid : applets.keySet()) {
             if (aid.equals(lookupAid)) {
-                return (AppletHolder) applets.get(aid);
+                return applets.get(aid);
             }
         }
         return null;
@@ -130,7 +125,8 @@ public class SimulatorRuntime {
             return null;
         }
         return a.getAppletClass();
-    }   
+    }
+
     /**
      * Load applet
      */
@@ -140,6 +136,35 @@ public class SimulatorRuntime {
             SystemException.throwIt(SystemException.ILLEGAL_AID);
         }
         applets.put(aid, new AppletHolder(appletClass));
+    }
+
+    /**
+     * Delete applet
+     */
+    protected void deleteApplet(AID aid) {
+        AppletHolder appletHolder = lookupApplet(aid);
+        if (appletHolder == null) {
+            throw new SystemException(SystemException.ILLEGAL_AID);
+        }
+
+        applets.remove(aid);
+        Applet applet = appletHolder.getApplet();
+        if (applet == null) {
+            return;
+        }
+
+        if (getApplet(currentAID) == applet) {
+            deselect(appletHolder);
+        }
+
+        if (applet instanceof AppletEvent) {
+            try {
+                ((AppletEvent) applet).uninstall();
+            }
+            catch (Exception e) {
+                // ignore all
+            }
+        }
     }
 
     /**
@@ -154,7 +179,7 @@ public class SimulatorRuntime {
             ah = lookupApplet(aid);
         }
         if (ah == null) {
-            SystemException.throwIt(SystemException.ILLEGAL_AID);
+            throw new SystemException(SystemException.ILLEGAL_AID);
         }
         ah.setApplet(applet);
         ah.register();
@@ -163,54 +188,27 @@ public class SimulatorRuntime {
     }
 
     /**
-     * Select applet for using
-     * @param aid applet aid
+     * Select applet
+     * @param aid Applet AID
      * @return data from select command
      */
     byte[] selectApplet(AID aid) {
-        Applet newApplet = getApplet(aid);
-        // deselect previous selected applet
-        if (currentAID != null) {
-            try {
-                Applet applet = getApplet(currentAID);
-                applet.deselect();
-            } catch (Exception e) {
-                // ignore all
-            } finally {
-                if (SimulatorSystem.getTransactionDepth() != 0) {
-                    SimulatorSystem.abortTransaction();
-                }
-            }
+        if (aid == null) {
+            throw new NullPointerException("aid");
         }
-        if (newApplet == null) {
-            return null;
-        }
-        // select new applet
-        try {
-            newApplet.select();
-            previousAID = currentAID;
-            currentAID = aid;
-            selecting = true;
 
-            byte[] aidBuffer = new byte[16];
-            byte len = aid.getBytes(aidBuffer, (short) 0);
+        byte[] aidBuffer = new byte[16];
+        byte length = aid.getBytes(aidBuffer, (short) 0);
 
-            byte[] selectCmd = new byte[len + ISO7816.OFFSET_CDATA];
-            selectCmd[ISO7816.OFFSET_CLA] = 0x00;
-            selectCmd[ISO7816.OFFSET_INS] = ISO7816.INS_SELECT;
-            selectCmd[ISO7816.OFFSET_P1] = 0x04;
-            selectCmd[ISO7816.OFFSET_P2] = 0x00;
-            selectCmd[ISO7816.OFFSET_LC] = len;
-            System.arraycopy(aidBuffer, 0, selectCmd, ISO7816.OFFSET_CDATA, len);
-            return this.transmitCommand(selectCmd);
-        } catch (Exception e) {
-        } finally {
-            if (SimulatorSystem.getTransactionDepth() != 0) {
-                SimulatorSystem.abortTransaction();
-            }
-            selecting  = false;
-        }
-        return null;
+        byte[] selectCmd = new byte[length + ISO7816.OFFSET_CDATA];
+        selectCmd[ISO7816.OFFSET_CLA] = ISO7816.CLA_ISO7816;
+        selectCmd[ISO7816.OFFSET_INS] = ISO7816.INS_SELECT;
+        selectCmd[ISO7816.OFFSET_P1] = 0x04;
+        selectCmd[ISO7816.OFFSET_P2] = 0x00;
+        selectCmd[ISO7816.OFFSET_LC] = length;
+        System.arraycopy(aidBuffer, 0, selectCmd, ISO7816.OFFSET_CDATA, length);
+
+        return transmitCommand(selectCmd);
     }
 
     /**
@@ -218,12 +216,9 @@ public class SimulatorRuntime {
      * @param aThis applet
      * @return true if applet is being selected
      */
-	public boolean isAppletSelecting(Applet aThis) {
-		if(aThis.equals(getApplet(getAID()))) {
-			return selecting;
-		}
-		return false;
-	}
+    public boolean isAppletSelecting(Applet aThis) {
+        return aThis == getApplet(getAID()) && selecting;
+    }
 
     /**
      * Transmit APDU to previous selected applet
@@ -232,21 +227,39 @@ public class SimulatorRuntime {
      * @throws SystemException <code>SystemException.ILLEGAL_USE</code> if appplet not selected before
      */
     byte[] transmitCommand(byte[] command) throws SystemException {
-        Applet applet = getApplet(getAID());
+        final ApduCase apduCase = ApduCase.getCase(command);
+        final byte[] theSW = new byte[2];
         byte[] response;
-        Util.arrayFillNonAtomic(theSW, (short) 0, (short) 2, (byte) 0);
+
+        Applet applet = getApplet(getAID());
+
+        selecting = false;
+        // check if there is an applet to be selected
+        if (!apduCase.isExtended() && isAppletSelectionApdu(command)) {
+            AID newAid = findAppletForSelectApdu(command, apduCase);
+            if (newAid != null) {
+                deselect(lookupApplet(getAID()));
+                currentAID = newAid;
+                applet = getApplet(getAID());
+                selecting = true;
+            }
+            else if (applet == null) {
+                Util.setShort(theSW, (short) 0, ISO7816.SW_APPLET_SELECT_FAILED);
+                return theSW;
+            }
+        }
+
         if (applet == null) {
             throw new SystemException(SystemException.ILLEGAL_USE);
         }
-        if (isExtendedAPDU(command)) {
+
+        if (apduCase.isExtended()) {
             if (applet instanceof ExtendedLength) {
                 SimulatorSystem.setExtendedApduMode(true);
             }
             else {
-                Util.setShort(theSW, (short) 0, ISO7816.SW_WRONG_LENGTH);
-                response = new byte[2];
-                Util.arrayCopyNonAtomic(theSW, (short) 0, response, (short) 0, (short) 2);
-                return response;
+                Util.setShort(theSW, (short)0, ISO7816.SW_WRONG_LENGTH);
+                return theSW;
             }
         }
         else {
@@ -254,6 +267,19 @@ public class SimulatorRuntime {
         }
 
         try {
+            if (selecting) {
+                boolean success;
+                try {
+                    success = applet.select();
+                }
+                catch (Exception e) {
+                    success = false;
+                }
+                if (!success) {
+                    throw new ISOException(ISO7816.SW_APPLET_SELECT_FAILED);
+                }
+            }
+
             // set apdu
             APDU apdu = SimulatorSystem.getCurrentAPDU();
             apduPrivateResetMethod.invoke(apdu, command);
@@ -267,6 +293,10 @@ public class SimulatorRuntime {
                 Util.setShort(theSW, (short) 0, ((CardRuntimeException) e).getReason());
             }
         }
+        finally {
+            selecting = false;
+        }
+
         // if theSW = 0x61XX or 0x9XYZ than return data (ISO7816-3)
         if(theSW[0] == 0x61 || (theSW[0] >= (byte)0x90 && theSW[0]<=0x9F)) {
             response = new byte[responseBufferSize + 2];
@@ -274,8 +304,7 @@ public class SimulatorRuntime {
             Util.arrayCopyNonAtomic(theSW, (short) 0, response, responseBufferSize, (short) 2);
         }
         else {
-            response = new byte[2];
-            Util.arrayCopyNonAtomic(theSW, (short) 0, response, (short) 0, (short) 2);
+            response = theSW;
         }
 
         Util.arrayFillNonAtomic(responseBuffer, (short) 0, (short) 255, (byte) 0);
@@ -283,8 +312,41 @@ public class SimulatorRuntime {
         return response;
     }
 
-    private boolean isExtendedAPDU(byte[] command) {
-        return ApduCase.getCase(command).isExtended();
+    protected AID findAppletForSelectApdu(byte[] selectApdu, ApduCase apduCase) {
+        if (apduCase == ApduCase.Case1 || apduCase == ApduCase.Case2) {
+            // on a regular Smartcard we would select the CardManager applet
+            // in this case we just select the first applet
+            return applets.isEmpty() ? null : applets.firstKey();
+        }
+
+        for (AID aid : applets.keySet()) {
+            if (aid.equals(selectApdu, ISO7816.OFFSET_CDATA, selectApdu[ISO7816.OFFSET_LC])) {
+                return aid;
+            }
+        }
+
+        for (AID aid : applets.keySet()) {
+            if (aid.partialEquals(selectApdu, ISO7816.OFFSET_CDATA, selectApdu[ISO7816.OFFSET_LC])) {
+                return aid;
+            }
+        }
+
+        return null;
+    }
+
+    protected void deselect(AppletHolder appletHolder) {
+        if (appletHolder != null) {
+            try {
+                Applet applet = appletHolder.getApplet();
+                applet.deselect();
+            } catch (Exception e) {
+                // ignore all
+            }
+        }
+        if (SimulatorSystem.getTransactionDepth() != 0) {
+            SimulatorSystem.abortTransaction();
+        }
+        // TODO perform CLEAR_ON_DESELECT
     }
 
     /**
@@ -301,17 +363,17 @@ public class SimulatorRuntime {
      * powerdown/powerup
      */
     void reset() {
-        Iterator aids = applets.keySet().iterator();
-        ArrayList aidsToTrash = new ArrayList();
+        Iterator<AID> aids = applets.keySet().iterator();
+        ArrayList<AID> aidsToTrash = new ArrayList<AID>();
         while (aids.hasNext()) {
-            AID aid = (AID) aids.next();
+            AID aid = aids.next();
             AppletHolder ah = lookupApplet(aid);
             if (ah.getState() != AppletHolder.INSTALLED) {
                 aidsToTrash.add(aid);
             }
         }
-        for(int i=0;i<aidsToTrash.size();i++) {
-            applets.remove(aidsToTrash.get(i));
+        for (AID anAidsToTrash : aidsToTrash) {
+            deleteApplet(anAidsToTrash);
         }
 
         Arrays.fill(responseBuffer, (byte) 0);
@@ -322,14 +384,14 @@ public class SimulatorRuntime {
     }
 
     void resetRuntime() {
-        Iterator aids = applets.keySet().iterator();
-        ArrayList aidsToTrash = new ArrayList();
+        Iterator<AID> aids = applets.keySet().iterator();
+        ArrayList<AID> aidsToTrash = new ArrayList<AID>();
         while (aids.hasNext()) {
-            AID aid = (AID) aids.next();
+            AID aid = aids.next();
             aidsToTrash.add(aid);
         }
-        for(int i=0;i<aidsToTrash.size();i++) {
-            applets.remove(aidsToTrash.get(i));
+        for (AID anAidsToTrash : aidsToTrash) {
+            deleteApplet(anAidsToTrash);
         }
 
         Arrays.fill(responseBuffer, (byte) 0);
@@ -338,7 +400,20 @@ public class SimulatorRuntime {
         previousAID = null;
         appletToInstallAID = null;
     }
-    
+
+    static boolean isAppletSelectionApdu(byte[] apdu) {
+        final byte channelMask = (byte) 0xFC; // mask out %b000000xx
+        final byte p2Mask = (byte) 0xE3; // mask out %b000xxx00
+
+        final byte cla = (byte) (apdu[ISO7816.OFFSET_CLA] & channelMask);
+        final byte ins = apdu[ISO7816.OFFSET_INS];
+        final byte p1 = apdu[ISO7816.OFFSET_P1];
+        final byte p2 = (byte) (apdu[ISO7816.OFFSET_P2] & p2Mask);
+
+        return cla == ISO7816.CLA_ISO7816 && ins == ISO7816.INS_SELECT &&
+                p1 == 4 && p2 == 0;
+    }
+
     // internal class which is holds Applet instance and it's state
     class AppletHolder {
         final static byte DOWNLOADING = 0;
@@ -382,6 +457,5 @@ public class SimulatorRuntime {
         Class getAppletClass(){
             return appletClass;
         }
-    
     }
 }

--- a/src/main/java/com/licel/jcardsim/samples/MultiInstanceApplet.java
+++ b/src/main/java/com/licel/jcardsim/samples/MultiInstanceApplet.java
@@ -1,0 +1,77 @@
+package com.licel.jcardsim.samples;
+
+import javacard.framework.*;
+
+public class MultiInstanceApplet extends BaseApplet implements AppletEvent {
+    private static final byte CLA = (byte) 0x90;
+    private static final byte INS_GET_FULL_AID = 0;
+    private static final byte INS_GET_COUNT = 2;
+    private static final byte INS_MAKE_UNUSABLE = 4;
+
+    private static final byte CLA_MASK = (byte) 0xF0;
+    private static short instanceCounter = 0;
+
+    private boolean locked = false;
+
+    public static void install(byte[] bArray, short bOffset, byte bLength) {
+        new MultiInstanceApplet().register();
+    }
+
+    protected MultiInstanceApplet() {
+        ++ instanceCounter;
+    }
+
+    @Override
+    public boolean select() {
+        return !locked;
+    }
+
+    public void process(APDU apdu) {
+        byte[] buffer = apdu.getBuffer();
+
+        final short readCount = apdu.setIncomingAndReceive();
+        final short lc = apdu.getIncomingLength();
+        final short offsetCData = apdu.getOffsetCdata();
+        short read = readCount;
+        while (read < lc) {
+            read += apdu.receiveBytes(read);
+        }
+
+        if (selectingApplet()) {
+            // return FCI with AID from SELECT
+            byte dataSize = buffer[ISO7816.OFFSET_LC];
+            buffer[1] = 0x6F; // Tag: File Control Information (FCI) Template
+            buffer[2] = (byte) (dataSize + 2);
+            buffer[3] = (byte) 0x84;  // Tag: Dedicated File (DF) Name
+            buffer[4] = dataSize;
+            apdu.setOutgoingAndSend((short) 1, (short)(dataSize + 4));
+            return;
+        }
+
+        if ((buffer[ISO7816.OFFSET_CLA] & CLA_MASK) != CLA) {
+            ISOException.throwIt(ISO7816.SW_CLA_NOT_SUPPORTED);
+        }
+
+        switch (buffer[ISO7816.OFFSET_INS]) {
+            case INS_GET_FULL_AID: {
+                short dataSize = JCSystem.getAID().getBytes(buffer, (short) 0);
+                apdu.setOutgoingAndSend((short)0, dataSize);
+                break;
+            }
+            case INS_GET_COUNT: {
+                Util.setShort(buffer, (short)0, instanceCounter);
+                apdu.setOutgoingAndSend((short)0, (short) 2);
+            }
+            case INS_MAKE_UNUSABLE: {
+                locked = true;
+                break;
+            }
+            default:
+                ISOException.throwIt(ISO7816.SW_INS_NOT_SUPPORTED);
+        }
+    }
+
+    public void uninstall() {
+        -- instanceCounter;
+    }
+}

--- a/src/main/java/com/licel/jcardsim/utils/AIDUtil.java
+++ b/src/main/java/com/licel/jcardsim/utils/AIDUtil.java
@@ -1,0 +1,52 @@
+package com.licel.jcardsim.utils;
+
+import javacard.framework.AID;
+import org.bouncycastle.util.encoders.Hex;
+
+import java.util.Comparator;
+
+public final class AIDUtil {
+    /**
+     * Create an AID from a byte array
+     * @param aidBytes AID bytes
+     * @return aid
+     * @throws java.lang.NullPointerException if <code>aidBytes</code> is null
+     * @throws java.lang.IllegalArgumentException if <code>aidBytes.length</code> is incorrect
+     */
+    public static AID create(byte[] aidBytes) {
+        if (aidBytes == null) {
+            throw new NullPointerException("aidString");
+        }
+        if (aidBytes.length < 5 || aidBytes.length > 16) {
+            throw new IllegalArgumentException("AID size must be between 5 and 16 but was " +  aidBytes.length);
+        }
+        return new AID(aidBytes, (short) 0, (byte) aidBytes.length);
+    }
+
+    /**
+     * Create an AID from a byte array
+     * @param aidString AID bytes as hex string
+     * @return aid
+     * @throws java.lang.NullPointerException if <code>aidString</code> is null
+     * @throws java.lang.IllegalArgumentException if length is incorrect
+     */
+    public static AID create(String aidString) {
+        if (aidString == null) {
+            throw new NullPointerException("aidString");
+        }
+        return create(Hex.decode(aidString));
+    }
+
+    /**
+     * @return a Comparator for AIDs
+     */
+    public static Comparator<AID> comparator() {
+        return new Comparator<AID>() {
+            public int compare(AID aid, AID aid2) {
+                return aid.toString().compareTo(aid2.toString());
+            }
+        };
+    }
+
+    private AIDUtil() {}
+}

--- a/src/main/java/com/licel/jcardsim/utils/ByteUtil.java
+++ b/src/main/java/com/licel/jcardsim/utils/ByteUtil.java
@@ -1,0 +1,70 @@
+package com.licel.jcardsim.utils;
+
+import org.bouncycastle.util.encoders.Hex;
+
+public final class ByteUtil {
+    private static final char[] hexArray = "0123456789ABCDEF".toCharArray();
+
+    /**
+     * Create byte array from hex string
+     * @param hexString hex string
+     * @return new byte array
+     * @throws java.lang.NullPointerException if <code>hexString</code> is null
+     */
+    public static byte[] byteArray(String hexString) {
+        if (hexString == null) {
+            throw new NullPointerException("hexArray");
+        }
+        return Hex.decode(hexString);
+    }
+
+    /**
+     * Convert byte array into hex string
+     * @param bytes hex string
+     * @return hexString
+     * @throws java.lang.NullPointerException if <code>bytes</code> is null
+     */
+    public static String hexString(byte[] bytes) {
+        // http://stackoverflow.com/questions/9655181/convert-from-byte-array-to-hex-string-in-java
+        if (bytes == null) {
+            throw new NullPointerException("bytes");
+        }
+        char[] hexChars = new char[bytes.length * 2];
+        for ( int j = 0; j < bytes.length; j++ ) {
+            int v = bytes[j] & 0xFF;
+            hexChars[j * 2] = hexArray[v >>> 4];
+            hexChars[j * 2 + 1] = hexArray[v & 0x0F];
+        }
+        return new String(hexChars);
+    }
+
+    /**
+     * Extract status word from APDU
+     * @param apduBuffer apdu bytes
+     * @return status word
+     * @throws java.lang.NullPointerException if <code>apduBuffer</code> is null
+     * @throws java.lang.IllegalArgumentException if <code>apduBuffer.length</code>  is &lt; 2
+     */
+    public static short getSW(byte[] apduBuffer) {
+        if (apduBuffer == null) {
+            throw new NullPointerException("bytes");
+        }
+        if (apduBuffer.length < 2) {
+            throw new IllegalArgumentException("bytes.length must be at least 2");
+        }
+        return getShort(apduBuffer, apduBuffer.length - 2);
+    }
+
+    /**
+     * Read short from array
+     * @see javacard.framework.Util#getShort(byte[], short)
+     * @param bArray byte array
+     * @param offset offset
+     * @return short value
+     */
+    public static short getShort(byte[] bArray, int offset) {
+        return (short) (((short) bArray[offset] << 8) + ((short) bArray[offset + 1] & 0xff));
+    }
+
+    private ByteUtil() {}
+}

--- a/src/main/java/javacard/framework/AID.java
+++ b/src/main/java/javacard/framework/AID.java
@@ -16,6 +16,8 @@
 
 package javacard.framework;
 
+import com.licel.jcardsim.utils.ByteUtil;
+
 /**
  * This class encapsulates the Application Identifier (AID) associated with an applet.
  * An AID is defined in ISO 7816-5 to be a sequence of bytes between 5 and 16 bytes in length.
@@ -42,7 +44,6 @@ package javacard.framework;
  *
  */
 public class AID {
-
     byte aid[];
 
     /**
@@ -209,5 +210,10 @@ public class AID {
         }
         Util.arrayCopy(aid, aidOffset, dest, oOffset, copyLen);
         return (byte) copyLen;
+    }
+
+    @Override
+    public String toString() {
+        return ByteUtil.hexString(aid);
     }
 }

--- a/src/main/java/javacard/framework/APDU.java
+++ b/src/main/java/javacard/framework/APDU.java
@@ -5,6 +5,7 @@
 package javacard.framework;
 
 import com.licel.jcardsim.base.SimulatorSystem;
+import com.licel.jcardsim.utils.ByteUtil;
 
 import java.util.Arrays;
 
@@ -887,7 +888,7 @@ public final class APDU {
         int offset = getOffsetCdata() + getIncomingLength();
         short le;
         if (extended) {
-            le = (short) (((short) buffer[offset] << 8) + ((short) buffer[offset + 1] & 0xff));
+            le = ByteUtil.getShort(buffer, offset);
         } else {
             le = (short) (0xFF & buffer[offset]);
         }

--- a/src/test/java/com/licel/jcardsim/base/DeleteTest.java
+++ b/src/test/java/com/licel/jcardsim/base/DeleteTest.java
@@ -1,0 +1,52 @@
+package com.licel.jcardsim.base;
+
+import com.licel.jcardsim.samples.MultiInstanceApplet;
+import com.licel.jcardsim.utils.AIDUtil;
+import com.licel.jcardsim.utils.ByteUtil;
+import javacard.framework.AID;
+import javacard.framework.ISO7816;
+import javacard.framework.Util;
+import junit.framework.TestCase;
+
+public class DeleteTest extends TestCase {
+    private static final byte CLA = (byte) 0x90;
+    private static final byte INS_GET_COUNT = 2;
+
+    public DeleteTest(String name) {
+        super(name);
+    }
+
+    public void testDeleteWorks() {
+        byte[] result;
+        AID aid1 = AIDUtil.create("d0000cafe00001");
+        AID aid2 = AIDUtil.create("d0000cafe00002");
+
+        Simulator simulator = new Simulator();
+
+        // install first instance
+        simulator.installApplet(aid1, MultiInstanceApplet.class);
+        simulator.selectApplet(aid1);
+
+        // check instance counter == 1
+        result = simulator.transmitCommand(new byte[]{CLA, INS_GET_COUNT, 0, 0});
+        assertEquals(1, ByteUtil.getShort(result, 0));
+        assertEquals(ISO7816.SW_NO_ERROR, ByteUtil.getSW(result));
+
+        // install second instance
+        simulator.installApplet(aid2, MultiInstanceApplet.class);
+
+        // check instance counter == 2
+        result = simulator.transmitCommand(new byte[]{CLA, INS_GET_COUNT, 0, 0});
+        assertEquals(2, ByteUtil.getShort(result, 0));
+        assertEquals(ISO7816.SW_NO_ERROR, ByteUtil.getSW(result));
+
+        // delete instance 1
+        simulator.deleteApplet(aid1);
+
+        // check instance counter == 1
+        simulator.selectApplet(aid2);
+        result = simulator.transmitCommand(new byte[]{CLA, INS_GET_COUNT, 0, 0});
+        assertEquals(1, ByteUtil.getShort(result, 0));
+        assertEquals(ISO7816.SW_NO_ERROR, ByteUtil.getSW(result));
+    }
+}

--- a/src/test/java/com/licel/jcardsim/base/SelectTest.java
+++ b/src/test/java/com/licel/jcardsim/base/SelectTest.java
@@ -1,0 +1,119 @@
+package com.licel.jcardsim.base;
+
+import com.licel.jcardsim.samples.MultiInstanceApplet;
+import com.licel.jcardsim.utils.AIDUtil;
+import javacard.framework.*;
+import junit.framework.TestCase;
+import org.bouncycastle.util.encoders.Hex;
+
+import java.util.Arrays;
+
+public class SelectTest extends TestCase {
+    private static final byte CLA = (byte) 0x90;
+    private static final byte INS_GET_FULL_AID = 0;
+
+    private static boolean selectedCalled;
+
+    private static class UnselectableApplet extends Applet {
+        public static void install(byte[] bArray, short bOffset, byte bLength) {
+            new UnselectableApplet().register();
+        }
+
+        @Override
+        public boolean select() {
+            selectedCalled = true;
+            return false;
+        }
+
+        @Override
+        public void process(APDU apdu) throws ISOException {
+        }
+    }
+
+    public SelectTest(String name) {
+        super(name);
+    }
+
+    private AID aid(String s) {
+        byte[] ba = Hex.decode(s);
+        return new AID(ba, (byte)0, (byte)ba.length);
+    }
+
+    public void testAidComparator() {
+        AID[] input = new AID[] {
+                aid("A000008812"),
+                aid("FF00066767"),
+                aid("D0000CAFE001"),
+                aid("D0000CAFE000"),
+                aid("D0000CAFE00023"),
+                aid("D0000CAFE00001"),
+                aid("0100CAFE01"),
+                aid("0200888888")
+        };
+        String expected = "[0100CAFE01, 0200888888, A000008812, " +
+                "D0000CAFE000, D0000CAFE00001, D0000CAFE00023, D0000CAFE001, FF00066767]";
+        Arrays.sort(input, AIDUtil.comparator());
+        assertEquals(expected, Arrays.toString(input));
+    }
+
+    private Simulator prepareSimulator() {
+        AID aid0 = aid("010203040506070809");
+        AID aid1 = aid("d0000cafe00001");
+        AID aid2 = aid("d0000cafe00002");
+
+        Simulator simulator = new Simulator();
+        simulator.installApplet(aid0, MultiInstanceApplet.class);
+        simulator.installApplet(aid2, MultiInstanceApplet.class);
+        simulator.installApplet(aid1, MultiInstanceApplet.class);
+        return simulator;
+    }
+
+    public void testPartialSelectWorks1() {
+        Simulator simulator = prepareSimulator();
+
+        // should select d0000cafe00001
+        assertTrue(simulator.selectApplet(aid("d0000cafe0")));
+        byte[] expected = Hex.decode("d0000cafe000019000");
+        byte[] actual = simulator.transmitCommand(new byte[]{CLA,INS_GET_FULL_AID,0,0});
+        assertEquals(Arrays.toString(expected), Arrays.toString(actual));
+    }
+
+    public void testPartialSelectWorks2() {
+        Simulator simulator = prepareSimulator();
+
+        // should select d0000cafe00001
+        simulator.transmitCommand(new byte[]{0, ISO7816.INS_SELECT, 4, 0, 1, (byte) 0xD0});
+
+        byte[] expected = Hex.decode("d0000cafe000019000");
+        byte[] actual = simulator.transmitCommand(new byte[]{CLA,INS_GET_FULL_AID,0,0});
+        assertEquals(Arrays.toString(expected), Arrays.toString(actual));
+    }
+
+    public void testEmptySelectWorks() {
+        final byte[] expected = Hex.decode("0102030405060708099000");
+        Simulator simulator = prepareSimulator();
+
+        // should select 010203040506070809
+        simulator.transmitCommand(new byte[]{0, ISO7816.INS_SELECT, 4, 0});
+        byte[] actual = simulator.transmitCommand(new byte[]{CLA,INS_GET_FULL_AID,0,0});
+        assertEquals(Arrays.toString(expected), Arrays.toString(actual));
+
+        // should select 010203040506070809
+        simulator.transmitCommand(new byte[]{0, ISO7816.INS_SELECT, 4, 0, 0});
+        actual = simulator.transmitCommand(new byte[]{CLA,INS_GET_FULL_AID,0,0});
+        assertEquals(Arrays.toString(expected), Arrays.toString(actual));
+    }
+
+    public void testCanNotSelectUnselectableApplet() {
+        selectedCalled = false;
+
+        AID aid = aid("010203040506070809");
+        Simulator simulator = new Simulator();
+        simulator.installApplet(aid, UnselectableApplet.class);
+
+        byte[] result = simulator.selectAppletWithResult(aid);
+        assertEquals(2, result.length);
+        assertEquals(ISO7816.SW_APPLET_SELECT_FAILED, Util.getShort(result, (short)0));
+        assertTrue(selectedCalled);
+    }
+}

--- a/src/test/java/com/licel/jcardsim/smartcardio/JCardSimProviderTest.java
+++ b/src/test/java/com/licel/jcardsim/smartcardio/JCardSimProviderTest.java
@@ -92,7 +92,7 @@ public class JCardSimProviderTest extends TestCase {
         assertEquals(response.getSW(), 0x9000);
         assertEquals(true, Arrays.equals(response.getData(), aidBytes));
         // select applet
-        CommandAPDU selectApplet = new CommandAPDU(ISO7816.CLA_ISO7816, ISO7816.INS_SELECT, 0, 0, Hex.decode(TEST_APPLET_AID));
+        CommandAPDU selectApplet = new CommandAPDU(ISO7816.CLA_ISO7816, ISO7816.INS_SELECT, 4, 0, Hex.decode(TEST_APPLET_AID));
         response = jcsChannel.transmit(selectApplet);
         assertEquals(response.getSW(), 0x9000);
         // test NOP


### PR DESCRIPTION
- SELECT detection now checks for P1=0x04 and P2=%b000xxx00i, if no
  applet can be be found the APDU is forwarded to the current applet.
  (fixes #39)
- Add support for SELECT with partial AIDs
- Check return value of Applet#select() during Applet selection
- Allow applet deletion via Simulator#deleteApplet(AID)
- Add support for AppletEvent#uninstall()
- Add AIDUtil and ByteUtil
