### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ jCardSim (Official repo of the [jCardSim](http://jcardsim.org) project)
 
 ![alt text](https://licel.ru/wp-content/uploads/DCA2013_Badge_Winner.jpg "jCardSim is a winner of Duke's Choice 2013")
 
-**Please note** that we moved our code repository here from Google Code. 
+**Please note** that we moved our code repository from Google Code to GitHub.
 
-jCardSim is an open source simulator implements Java Card, v.2.2.1/2:
+jCardSim is an open source simulator for Java Card, v.2.2.1/2:
 
 * `javacard.framework.*`
 * `javacard.framework.security.*`
@@ -16,7 +16,7 @@ jCardSim is an open source simulator implements Java Card, v.2.2.1/2:
 Key Features:
 
 * Rapid application prototyping
-* Ease of writing Unit-tests (5 lines of code)
+* Simplifies unit testing (5 lines of code)
 
 ```java
 //1. create simulator
@@ -26,14 +26,14 @@ simulator.installApplet(appletAID, HelloWorldApplet.class);
 //3. select applet
 simulator.selectApplet(appletAID);
 //4. send apdu
-ResponseAPDU response = simulator.transmitCommand(new CommandAPDU(0x01, 0x01, 0x00, 0x00));
+ResponseAPDU response = simulator.transmitCommand(new CommandAPDU(0x00, 0x01, 0x00, 0x00));
 //5. check response
 assertEquals(0x9000, response.getSW());
 ```
 
 * Emulation of Java Card Terminal, ability to use `javax.smartcardio`
 * APDU scripting (scripts are compatible with apdutool from Java Card Development Kit)
-* Ease of verification tests creation (Common Criteria)
+* Simplifies verification tests creation (Common Criteria)
 
 *JavaDoc*: https://jcardsim.googlecode.com/svn/trunk/javadoc/index.html
 
@@ -61,23 +61,23 @@ assertEquals(0x9000, response.getSW());
 
 * **Implementation of javacard.security.***
 
-One of the main differences is the implementation of `javacard.security.*`: current version is analogous with NXP JCOP 31/36k card. For example, in jCardSim we have support an on-card `KeyPair.ALG_EC_F2M/ALG_RSA_CRT` key generation. Simulator from Oracle has only `KeyPair.ALG_RSA` and `KeyPair.ALG_EC_FP` support, which not supported on real cards.
+One of the main differences is the implementation of `javacard.security.*`: the current version is analogous to an NXP JCOP 31/36k card. For example, in jCardSim we have support for on-card `KeyPair.ALG_EC_F2M/ALG_RSA_CRT` key generation. Oracle's simulator only supports `KeyPair.ALG_RSA` and `KeyPair.ALG_EC_FP`, which are not supported by real cards.
 
 * **Execution of Java Card applications without converting into CAP**
 
-jCardSim can work with class files, without any conversions. This allows us to simplify and accelerate the development and writing of unit-tests.
+jCardSim can work with class files without any conversions. This allows us to simplify and accelerate the development and writing of unit tests.
 
 * **Simulator API**
 
-jCardSim has simple and usable API, which allows you to work with simulator like with real Java Card using `javax.smartcardio.*`.
+jCardSim has a simple and usable API, which also allows you to work with the simulator using `javax.smartcardio.*`.
 
 * **Cross-platform**
 
-jCardSim completely written in Java and can therefore be used at all platforms which supports Java (Windows, Linux, MacOS, etc).
+jCardSim is completely written in Java and can therefore be used on all platforms which support Java (Windows, Linux, MacOS, etc).
 
 ### How to help jCardSim?
 
-* Join team of jCardSim developers.
+* Join the team of jCardSim developers.
 * Try out [DexProtector](http://dexprotector.com). The product is designed for strong and robust protection of Android applications against reverse engineering and modification.
 * Licel has one more product you may be interested in - [Stringer Java Obfuscator](https://jfxstore.com/stringer). This tool provides all the features you need to comprehensively protect your Java applications.
 

--- a/sitedocs/getting_source_and_compiling.md
+++ b/sitedocs/getting_source_and_compiling.md
@@ -1,4 +1,4 @@
-jCardSim is an open source project and it would be pleasure for us to see you in commiters and contributors!  
+jCardSim is an open source project and it would be pleasure for us to see you as commiters and contributors!
 
 ### Source code
 The official jCardSim source repository is located at [https://github.com/licel/jcardsim](https://github.com/licel/jcardsim).
@@ -10,8 +10,8 @@ We are using [Maven](http://http://maven.apache.org/) for building. After downlo
 
 
 ### Development standards
-We are using the following principles in a jCardSim's development process: 
+We are using the following principles in jCardSim's development process:
 
 - [Test-Driven Development](http://en.wikipedia.org/wiki/Test-driven_development)
-- [Code Conventions for the Java Programming Language](http://www.oracle.com/technetwork/java/codeconv-138413.html)
+- [Code Conventions for the Java Programming Language](http://www.oracle.com/technetwork/java/codeconvtoc-136057.html)
 

--- a/sitedocs/quick_start_guide_simulator_api.md
+++ b/sitedocs/quick_start_guide_simulator_api.md
@@ -1,17 +1,17 @@
-jCardSim was originally developed for a fast prototyping of the Java Card applications, and writing unit-tests.
+jCardSim is intended for rapid prototyping of Java Card applications and unit testing.
 
 There are two ways to use the simulator:
 
- - Using of Simulator API
- - Using the `javax.smartcardio` for an interaction with JavaCard
+ - Using the Simulator API
+ - Using the `javax.smartcardio` API
 
 In both cases it is possible to interact with a remote instance of jCardSim. For example you may run one or multiple instances of virtual Java Card and connect to it via TCP/IP.  
 
 ### Using Simulator API's methods
 
-The main interface for working with simulator is `com.licel.jcardsim.io.JavaCardInterface`, its specification available [here](http://jcardsim.org/jcardsim/com/licel/jcardsim/io/JavaCardInterface.html). In order to get its implementation use `com.licel.jcardsim.io.CAD`.
+The main interface for working with the simulator is `com.licel.jcardsim.io.JavaCardInterface`, its specification is available [here](http://jcardsim.org/jcardsim/com/licel/jcardsim/io/JavaCardInterface.html). In order to get its implementation use `com.licel.jcardsim.io.CAD`.
 
-At first it is necessary to set connection parameters:
+At first it is necessary to set the connection parameters:
 
 	// 0 - Local Mode
 	// 1 - Remote Mode
@@ -33,13 +33,13 @@ Selecting:
 
 Sending an APDU command:
 
-	ResponseAPDU response = simulator.transmitCommand(new CommandAPDU(0x01, 0x01, 0x00, 0x00));
+	ResponseAPDU response = simulator.transmitCommand(new CommandAPDU(0x00, 0x01, 0x00, 0x00));
 
-And check a result of the execution:
+And check the result of the execution:
 
 	assertEquals(0x9000, response.getSW());
 
-The example of how to work with HelloWorldApplet (from first part of [Quick Start Guide: Using in CLI mode](http://jcardsim.org/docs/quick-start-guide-using-in-cli-mode)):
+An example of how to work with HelloWorldApplet (from the first part of [Quick Start Guide: Using in CLI mode](http://jcardsim.org/docs/quick-start-guide-using-in-cli-mode)):
 
 	System.setProperty("com.licel.jcardsim.terminal.type", "2");
 	CAD cad = new CAD(System.getProperties());
@@ -49,23 +49,23 @@ The example of how to work with HelloWorldApplet (from first part of [Quick Star
 	simulator.installApplet(appletAID, HelloWorldApplet.class);
 	simulator.selectApplet(appletAID);
 	// test NOP
-	ResponseAPDU response = simulator.transmitCommand(new CommandAPDU(0x01, 0x02, 0x00, 0x00));
+	ResponseAPDU response = simulator.transmitCommand(new CommandAPDU(0x00, 0x02, 0x00, 0x00));
 	assertEquals(0x9000, response.getSW());
 	// test hello world from card
-	response = simulator.transmitCommand(new CommandAPDU(0x01, 0x01, 0x00, 0x00));
+	response = simulator.transmitCommand(new CommandAPDU(0x00, 0x01, 0x00, 0x00));
 	assertEquals(0x9000, response.getSW());
 	assertEquals("Hello world !", new String(response.getData()));
 	// test echo
-	response = simulator.transmitCommand(new CommandAPDU(0x01, 0x01, 0x01, 0x00, ("Hello javacard world !").getBytes()));
+	response = simulator.transmitCommand(new CommandAPDU(0x00, 0x01, 0x01, 0x00, ("Hello javacard world !").getBytes()));
 	assertEquals(0x9000, response.getSW());
 	assertEquals("Hello javacard world !", new String(response.getData()));
 
 ### Using  `javax.smartcardio` for an interaction with JavaCard
-For ease of writing Unit tests for an applications which use `javax.smartcardio`, we have the provider for Java Card Terminal's emulation in jCardSim.
+To simplify unit testing of an applications that uses `javax.smartcardio`, we provide the jCardSim TerminalFactory.
 
 The complete example can be found at [JCardSimProviderTest.java](https://github.com/licel/jcardsim/blob/master/src/test/java/com/licel/jcardsim/smartcardio/JCardSimProviderTest.java).
 
-To use it you have to register jCardSim TerminalFactory Provider:
+To use it you have to register the jCardSim TerminalFactory Provider:
 
 	if (Security.getProvider("jCardSim") == null) {
 	       JCardSimProvider provider = new JCardSimProvider();
@@ -86,7 +86,7 @@ Choose terminal:
 	}
 
 Then, you can use `javax.smartcardio` API.
-> **Note:** Pre-installed applets can be configured using system properties: `System.setProperty(...)`, the format is equal with configuration file of the CLI mode of jCardSim.
+> **Note:** Pre-installed applets can be configured using system properties: `System.setProperty(...)`, the format is equal to the configuration file of the CLI mode of jCardSim.
 
 Example of how to work with HelloWorldApplet:  
 	
@@ -123,14 +123,14 @@ Example of how to work with HelloWorldApplet:
 	 response = jcsChannel.transmit(selectApplet);
 	 assertEquals(response.getSW(), 0x9000);
 	 // test NOP
-	 response = jcsChannel.transmit(new CommandAPDU(0x01, 0x02, 0x00, 0x00));
+	 response = jcsChannel.transmit(new CommandAPDU(0x00, 0x02, 0x00, 0x00));
 	 assertEquals(0x9000, response.getSW());
 	 // test hello world from card
-	 response = jcsChannel.transmit(new CommandAPDU(0x01, 0x01, 0x00, 0x00));
+	 response = jcsChannel.transmit(new CommandAPDU(0x00, 0x01, 0x00, 0x00));
 	 assertEquals(0x9000, response.getSW());
 	 assertEquals("Hello world !", new String(response.getData()));
 	 // test echo
-	 response = jcsChannel.transmit(new CommandAPDU(0x01, 0x01, 0x01, 0x00, ("Hello javacard world !").getBytes()));
+	 response = jcsChannel.transmit(new CommandAPDU(0x00, 0x01, 0x01, 0x00, ("Hello javacard world !").getBytes()));
 	 assertEquals(0x9000, response.getSW());
 	 assertEquals("Hello javacard world !", new String(response.getData()));
 

--- a/sitedocs/quick_start_guide_using_in_cli_mode.md
+++ b/sitedocs/quick_start_guide_using_in_cli_mode.md
@@ -3,38 +3,38 @@ Follow the link to download jCardSim jar archive:
 [https://github.com/licel/jcardsim/raw/master/jcardsim-2.2.2-all.jar](https://github.com/licel/jcardsim/raw/master/jcardsim-2.2.2-all.jar)
 
 ### Starting jCardSim in a CLI mode
-To simplify the development and debugging processes, jCardSim is working with a files of classes directly. You haven't to convert your application to CAP for an execution in simulator.
+To simplify the development and debugging process, jCardSim works directly with class files. You do not need to convert your Java Card applet to CAP in order to use it in the simulator.
 
-Simulator has CLI and API, so you can choose what you want to use. See more about using API and Unit Test writing in the second part of 
-[Quick Start Guide](http://jcardsim.org/docs/quick-start-guide-simulator-api).  
-For an application execution and interaction with through APDU scripts you should use `com.licel.jcardsim.utils.APDUScriptTool` class.
+The simulator has a CLI and an API, so you can choose what you want to use. See more about using API and unit testing in the second part of
+the [Quick Start Guide](http://jcardsim.org/docs/quick-start-guide-simulator-api).
+For sending APDUs via APDU scripts you should use the class `com.licel.jcardsim.utils.APDUScriptTool`.
 
 **Start parameters:**
 
 	java -cp jcardsim-2.2.1-all.jar com.licel.jcardsim.utils.APDUScriptTool <jcardsim.cfg> <apdu script> [out file]
 
 
-<code>jcardsim.cfg</code> — file with settings of simulator. Here you can set information about your applets. It has the following format:
+*jcardsim.cfg*, is a file with settings for the simulator. In it you can set information about your applets. It has the following format:
 
 	com.licel.jcardsim.card.applet.{index}.AID=<Applet AID>
 	com.licel.jcardsim.card.applet.{index}.Class=<Applet ClassName>
 
-where `{index}` is the number from 0 to 10.  
+where *{index}* is a number from 0 to 10.
 >**NOTE:** Applet classes and it's dependencies must be in class path when simulator starts.
 
-In an example case settings file will look like:
+An example settings file:
 
 	com.licel.jcardsim.card.applet.0.AID=010203040506070809
 	com.licel.jcardsim.card.applet.0.Class=com.licel.jcardsim.samples.HelloWorldApplet
 
-`<apdu script>` - file with APDU commands in C-APDU format, this file compatible with script format of apdutool from Java Card Development Kit.
+`<apdu script>` - file with APDU commands in C-APDU format. This file is compatible with the script format of *apdutool* from the Java Card Development Kit.
 
-C-APDUs ends with `(;)` and for the comments you should use `//`
+C-APDUs ends with `(;)` and comments begin with `//`
 
-APDU commands could be represented by DEC or HEX characters. HEX characters should start from `0x`.
-One C-APDU command can span multiple lines.
+APDU commands can be represented by DEC or HEX characters. HEX characters start with `0x`.
+One APDU command (C-APDU) can span multiple lines.
 
-C-APDU command has the following format:
+A C-APDU has the following format:
 
 	<CLA> <INS> <P1> <P2> <LC> [<byte 0> <byte 1> ... <byte LC-1>] <LE> ;
 where:  
@@ -46,27 +46,27 @@ where:
 `<byte 0> ... <byte LC-1>` :: input data bytes. 
 `<LE>`  :: ISO 7816- 4 expected output length. 1 byte
 
-As an example of Java Card Applet we will use `com.licel.jcardsim.samples.HelloWorld`. It is a simple applet, it can process following APDU commands:
+For this example we will use the `com.licel.jcardsim.samples.HelloWorld` Java Card Applet. It is a simple applet which processes the following APDU commands:
 
-- Do nothing `CLA=0x01 INS=0x02 P1=0x00 P2=0x00 LC=0x00`
-- Return bytes of "Hello world!" `CLA=0x01 INS=0x01 P1=0x00 P2=0x00 LC=0x00`
-- Return sended data (echo) `CLA=0x01 INS=0x01 P1=0x01 P2=0x00 LC=<length> DATA=<data>`
+- Do nothing `CLA=0x00 INS=0x02 P1=0x00 P2=0x00 LC=0x00`
+- Return bytes of "Hello world!" `CLA=0x00 INS=0x01 P1=0x00 P2=0x00 LC=0x00`
+- Return sended data (echo) `CLA=0x00 INS=0x01 P1=0x01 P2=0x00 LC=<length> DATA=<data>`
 
-Let's write C-APDU script for our HelloWorld applet:
+Let's write a C-APDU script for our HelloWorld applet:
 
 	// CREATE APPLET CMD
 	0x80 0xb8 0x00 0x00 0x10 0x9 0x01 0x02 0x03 0x04 0x05 0x06 0x07 0x8 0x09 0x05 0x00 0x00 0x02 0xF 0xF 0x7f;
 	// SELECT APPLET CMD
 	0x00 0xa4 0x00 0x00 0x09 0x01 0x02 0x03 0x04 0x05 0x06 0x07 0x8 0x09 0x2;
 	// TEST NOP
-	0x01 0x02 0x00 0x00 0x00 0x2;
+	0x00 0x02 0x00 0x00 0x00 0x2;
 	// test hello world from card
-	0x01 0x01 0x00 0x00 0x00 0x0d;
+	0x00 0x01 0x00 0x00 0x00 0x0d;
 	// test echo
-	0x01 0x01 0x01 0x00 0x0d 0x48 0x65 0x6c 0x6c 0x6f 0x20 0x77 0x6f 0x72 0x6c 0x64 0x20 0x21 0x0d;
+	0x00 0x01 0x01 0x00 0x0d 0x48 0x65 0x6c 0x6c 0x6f 0x20 0x77 0x6f 0x72 0x6c 0x64 0x20 0x21 0x0d;
 
 
-Now we are saving C-APDU script into helloworld.apdu file and starting the simulator. If we don't point out third parameter the result prints to the console.
+Now we save the C-APDU script into the file `helloworld.apdu` and start the simulator. If we do not provide a third parameter the results will be printed on the console.
 
 	java -cp jcardsim-2.2.1-all.jar com.licel.jcardsim.utils.APDUScriptTool jcardsim.cfg helloworld.apdu
 
@@ -74,10 +74,10 @@ Now we are saving C-APDU script into helloworld.apdu file and starting the simul
 
 	CLA: 80, INS: b8, P1: 00, P2: 00, Lc: 10, 09, 01, 02, 03, 04, 05, 06, 07, 08, 09, 05, 00, 00, 02, 0f, 0f, Le: 09, 01, 02, 03, 04, 05, 06, 07, 08, 09, SW1: 90, SW2: 00
 	CLA: 00, INS: a4, P1: 00, P2: 00, Lc: 09, 01, 02, 03, 04, 05, 06, 07, 08, 09, Le: 00, SW1: 90, SW2: 00
-	CLA: 01, INS: 02, P1: 00, P2: 00, Lc: 00, Le: 00, SW1: 90, SW2: 00
-	CLA: 01, INS: 01, P1: 00, P2: 00, Lc: 00, Le: 0d, 48, 65, 6c, 6c, 6f, 20, 77, 6f, 72, 6c, 64, 20, 21, SW1: 90, SW2: 00
-	CLA: 01, INS: 01, P1: 01, P2: 00, Lc: 0d, 48, 65, 6c, 6c, 6f, 20, 77, 6f, 72, 6c, 64, 20, 21, Le: 0d, 48, 65, 6c, 6c, 6f, 20, 77, 6f, 72, 6c, 64, 20, 21, SW1: 90, SW2: 00
+	CLA: 00, INS: 02, P1: 00, P2: 00, Lc: 00, Le: 00, SW1: 90, SW2: 00
+	CLA: 00, INS: 01, P1: 00, P2: 00, Lc: 00, Le: 0d, 48, 65, 6c, 6c, 6f, 20, 77, 6f, 72, 6c, 64, 20, 21, SW1: 90, SW2: 00
+	CLA: 00, INS: 01, P1: 01, P2: 00, Lc: 0d, 48, 65, 6c, 6c, 6f, 20, 77, 6f, 72, 6c, 64, 20, 21, Le: 0d, 48, 65, 6c, 6c, 6f, 20, 77, 6f, 72, 6c, 64, 20, 21, SW1: 90, SW2: 00
 
-The output is also comply with apdutool from the Java Card Development Kit.
+The output matches the format used by *apdutool*.
 
 > The second part: [Quick Start Guide: Simulator API](http://jcardsim.org/docs/quick-start-guide-simulator-api).

--- a/src/main/java/com/licel/jcardsim/base/ApduCase.java
+++ b/src/main/java/com/licel/jcardsim/base/ApduCase.java
@@ -19,7 +19,7 @@ import javacard.framework.ISO7816;
 import javacard.framework.Util;
 
 /**
- * Case of an <code>APDU</code>
+ * Case of an <code>APDU</code>.
  */
 public enum ApduCase {
     /**

--- a/src/main/java/com/licel/jcardsim/base/CardManager.java
+++ b/src/main/java/com/licel/jcardsim/base/CardManager.java
@@ -22,7 +22,7 @@ import javacard.framework.SystemException;
 import javacard.framework.Util;
 
 /**
- * CardManager
+ * CardManager.
  */
 public class CardManager {
 

--- a/src/main/java/com/licel/jcardsim/base/LoadFile.java
+++ b/src/main/java/com/licel/jcardsim/base/LoadFile.java
@@ -57,6 +57,7 @@ public final class LoadFile {
      * Create a LoadFile containing one module (JavaCard applet)
      * @param loadFileAID AID of the LoadFile (JavaCard Package AID)
      * @param moduleAid AID of the module/class
+     * @param appletClass the Applet class
      * @throws java.lang.NullPointerException if any argument is null
      * @throws java.lang.IllegalArgumentException if <code>modules</code> is empty
      */

--- a/src/main/java/com/licel/jcardsim/base/Module.java
+++ b/src/main/java/com/licel/jcardsim/base/Module.java
@@ -20,7 +20,7 @@ import javacard.framework.AID;
 import javacard.framework.Applet;
 
 /**
- * Represents a module (JavaCard Applet class)
+ * Represents a module (JavaCard Applet class).
  */
 public final class Module {
     private final AID aid;

--- a/src/main/java/com/licel/jcardsim/base/Simulator.java
+++ b/src/main/java/com/licel/jcardsim/base/Simulator.java
@@ -31,7 +31,7 @@ import javacard.framework.*;
 import org.bouncycastle.util.encoders.Hex;
 
 /**
- * Simulates a JavaCard
+ * Simulates a JavaCard.
  */
 public class Simulator implements JavaCardInterface {
 

--- a/src/main/java/com/licel/jcardsim/base/SimulatorRuntime.java
+++ b/src/main/java/com/licel/jcardsim/base/SimulatorRuntime.java
@@ -28,7 +28,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Base implementation of Java Card Runtime
+ * Base implementation of Java Card Runtime.
  * @see JCSystem
  * @see Applet
  */
@@ -103,7 +103,7 @@ public class SimulatorRuntime {
 
 
     /**
-     * Return current applet context AID or null
+     * @return current applet context AID or null
      */
     public AID getAID() {
         return currentAID;
@@ -111,6 +111,10 @@ public class SimulatorRuntime {
 
     /**
      * Lookup applet by aid contains in byte array
+     * @param buffer the byte array containing the AID bytes
+     * @param offset the start of AID bytes in <code>buffer</code>
+     * @param length the length of the AID bytes in <code>buffer</code>
+     * @return Applet AID or null
      */
     public AID lookupAID(byte buffer[], short offset, byte length) {
         // no construct new AID, iterate applets
@@ -124,6 +128,8 @@ public class SimulatorRuntime {
 
     /**
      * Lookup applet by aid
+     * @param lookupAid applet AID
+     * @return ApplicationInstance or null
      */
     public ApplicationInstance lookupApplet(AID lookupAid) {
         for (AID aid : applets.keySet()) {
@@ -135,7 +141,7 @@ public class SimulatorRuntime {
     }
 
     /**
-     * Return previous selected applet context AID or null
+     * @return previous selected applet context AID or null
      */
     public AID getPreviousContextAID() {
         return previousAID;
@@ -144,6 +150,7 @@ public class SimulatorRuntime {
     /**
      * Return <code>Applet</code> by it's AID or null
      * @param aid applet <code>AID</code>
+     * @return Applet or null
      */
     protected Applet getApplet(AID aid) {
         if (aid == null) {
@@ -156,6 +163,8 @@ public class SimulatorRuntime {
 
     /**
      * Load applet
+     * @param aid Applet AID
+     * @param appletClass Applet class
      */
     public void loadApplet(AID aid, Class<? extends Applet> appletClass) {
         if (generatedLoadFileAIDs.keySet().contains(aid)) {
@@ -170,6 +179,10 @@ public class SimulatorRuntime {
         loadLoadFile(new LoadFile(generatedAID, generatedAID, appletClass));
     }
 
+    /**
+     * Load a LoadFile
+     * @param loadFile LoadFile to load
+     */
     public void loadLoadFile(LoadFile loadFile) {
         AID key = loadFile.getAid();
         if (loadFiles.keySet().contains(key) || applets.keySet().contains(key)) {
@@ -180,6 +193,7 @@ public class SimulatorRuntime {
 
     /**
      * Delete applet
+     * @param aid Applet AID to delete
      */
     protected void deleteApplet(AID aid) {
         ApplicationInstance applicationInstance = lookupApplet(aid);
@@ -456,6 +470,7 @@ public class SimulatorRuntime {
 
     /**
      * @see javacard.framework.JCSystem#getTransactionDepth()
+     * @return 1 if transaction in progress, 0 if not
      */
     public byte getTransactionDepth() {
         return transactionDepth;
@@ -503,6 +518,9 @@ public class SimulatorRuntime {
 
     /**
      * @see javacard.framework.JCSystem#getAppletShareableInterfaceObject(javacard.framework.AID, byte)
+     * @param serverAID the AID of the server applet
+     * @param parameter optional parameter data
+     * @return the shareable interface object or <code>null</code>
      */
     public Shareable getSharedObject(AID serverAID, byte parameter) {
         Applet serverApplet = getApplet(serverAID);
@@ -515,6 +533,7 @@ public class SimulatorRuntime {
 
     /**
      * @see javacard.framework.JCSystem#isObjectDeletionSupported()
+     * @return always false
      */
     public boolean isObjectDeletionSupported() {
         return false;

--- a/src/main/java/com/licel/jcardsim/base/SimulatorSystem.java
+++ b/src/main/java/com/licel/jcardsim/base/SimulatorSystem.java
@@ -20,7 +20,7 @@ import javacard.framework.*;
 import java.lang.reflect.Constructor;
 
 /**
- * Base implementation of <code>JCSystem</code>
+ * Base implementation of <code>JCSystem</code>.
  * @see JCSystem
  */
 public class SimulatorSystem {

--- a/src/main/java/com/licel/jcardsim/base/TransientMemory.java
+++ b/src/main/java/com/licel/jcardsim/base/TransientMemory.java
@@ -23,7 +23,7 @@ import javacard.framework.JCSystem;
 import javacard.framework.SystemException;
 
 /**
- * Basic implementation of storage transient memory of JCRE
+ * Basic implementation of storage transient memory of JCRE.
  */
 public class TransientMemory {
     /** List of <code>CLEAR_ON_DESELECT</code> arrays */
@@ -33,6 +33,9 @@ public class TransientMemory {
 
     /**
      * @see javacard.framework.JCSystem#makeTransientBooleanArray(short, byte)
+     * @param length the length of the array
+     * @param event the <code>CLEAR_ON...</code> event which causes the array elements to be cleared
+     * @return the new transient array
      */
     public boolean[] makeBooleanArray(short length, byte event) {
         boolean[] array = new boolean[length];
@@ -42,6 +45,9 @@ public class TransientMemory {
 
     /**
      * @see javacard.framework.JCSystem#makeTransientByteArray(short, byte)
+     * @param length the length of the array
+     * @param event the <code>CLEAR_ON...</code> event which causes the array elements to be cleared
+     * @return the new transient array
      */
     public byte[] makeByteArray(int length, byte event) {
         byte[] array = new byte[length];
@@ -51,6 +57,9 @@ public class TransientMemory {
 
     /**
      * @see javacard.framework.JCSystem#makeTransientShortArray(short, byte)
+     * @param length the length of the array
+     * @param event the <code>CLEAR_ON...</code> event which causes the array elements to be cleared
+     * @return the new transient array
      */
     public short[] makeShortArray(short length, byte event) {
         short[] array = new short[length];
@@ -60,6 +69,9 @@ public class TransientMemory {
 
     /**
      * @see javacard.framework.JCSystem#makeTransientObjectArray(short, byte)
+     * @param length the length of the array
+     * @param event the <code>CLEAR_ON...</code> event which causes the array elements to be cleared
+     * @return the new transient array
      */
     public Object[] makeObjectArray(short length, byte event) {
         Object[] array = new Object[length];
@@ -69,6 +81,8 @@ public class TransientMemory {
 
     /**
      * @see javacard.framework.JCSystem#isTransient(Object)
+     * @param theObj the object being queried
+     * @return <code>NOT_A_TRANSIENT_OBJECT</code>, <code>CLEAR_ON_RESET</code>, or <code>CLEAR_ON_DESELECT</code>
      */
     public byte isTransient(Object theObj) {
         if (clearOnDeselect.contains(theObj)) {

--- a/src/main/java/com/licel/jcardsim/crypto/AsymmetricCipherImpl.java
+++ b/src/main/java/com/licel/jcardsim/crypto/AsymmetricCipherImpl.java
@@ -28,7 +28,7 @@ import org.bouncycastle.crypto.paddings.BlockCipherPadding;
 
 /*
  * Implementation <code>Cipher</code> with asymmetric keys based
- * on BouncyCastle CryptoAPI
+ * on BouncyCastle CryptoAPI.
  * @see Cipher
  */
 public class AsymmetricCipherImpl extends Cipher {

--- a/src/main/java/com/licel/jcardsim/crypto/AsymmetricSignatureImpl.java
+++ b/src/main/java/com/licel/jcardsim/crypto/AsymmetricSignatureImpl.java
@@ -36,7 +36,7 @@ import org.bouncycastle.crypto.signers.RSADigestSigner;
 
 /*
  * Implementation <code>Signature</code> with asymmetric keys based
- * on BouncyCastle CryptoAPI
+ * on BouncyCastle CryptoAPI.
  * @see Signature
  */
 public class AsymmetricSignatureImpl extends Signature implements SignatureMessageRecovery{

--- a/src/main/java/com/licel/jcardsim/crypto/ByteContainer.java
+++ b/src/main/java/com/licel/jcardsim/crypto/ByteContainer.java
@@ -22,7 +22,7 @@ import javacard.security.CryptoException;
 
 /**
  * This class contains byte array, initialization flag of this
- * array and memory type
+ * array and memory type.
  */
 public final class ByteContainer {
 
@@ -63,8 +63,8 @@ public final class ByteContainer {
      * with memory type <code>JCSystem.MEMORY_TYPE_PERSISTENT</code>
      * and fills it by defined byte array
      * @param buff byte array
-     * @param offset
-     * @param length
+     * @param offset offset in byte array
+     * @param length length of data in byte array
      */
     public ByteContainer(byte[] buff, short offset, short length) {
         setBytes(buff, offset, length);
@@ -93,7 +93,7 @@ public final class ByteContainer {
 
     /**
      * Fills <code>ByteContainer</code>by defined byte array
-     * @param buff
+     * @param buff byte array
      */
     public void setBytes(byte[] buff) {
         setBytes(buff, (short) 0, (short) buff.length);
@@ -101,9 +101,9 @@ public final class ByteContainer {
 
     /**
      * Fills <code>ByteContainer</code>by defined byte array
-     * @param buff
-     * @param offset
-     * @param length
+     * @param buff byte array
+     * @param offset offset in byte array
+     * @param length length of data in byte array
      */
     public void setBytes(byte[] buff, short offset, short length) {
         if (data == null) {
@@ -152,8 +152,8 @@ public final class ByteContainer {
     /**
      * Copy byte array representation of the <code>ByteContainer</code>
      * @param dest destination byte array
-     * @param offset
-     * @return bytes copies
+     * @param offset destination byte array offset
+     * @return bytes copied
      */
     public short getBytes(byte[] dest, short offset) {
         if (length == 0) {

--- a/src/main/java/com/licel/jcardsim/crypto/CRC16.java
+++ b/src/main/java/com/licel/jcardsim/crypto/CRC16.java
@@ -22,8 +22,8 @@ import javacard.security.CryptoException;
 
 /*
  * Implementation <code>Checksum</code>
- * ISO/IEC 3309 compliant 16 bit CRC algorithm.
- * on BouncyCastle CryptoAPI
+ * ISO/IEC 3309 compliant 16 bit CRC algorithm
+ * on BouncyCastle CryptoAPI.
  * @see Checksum
  */
 public class CRC16 extends Checksum {

--- a/src/main/java/com/licel/jcardsim/crypto/CRC32.java
+++ b/src/main/java/com/licel/jcardsim/crypto/CRC32.java
@@ -23,7 +23,7 @@ import javacard.security.CryptoException;
 /*
  * Implementation <code>Checksum</code>
  * ISO/IEC 3309 compliant 32 bit CRC algorithm.
- * on BouncyCastle CryptoAPI
+ * on BouncyCastle CryptoAPI.
  * @see Checksum
  */
 public class CRC32 extends Checksum {

--- a/src/main/java/com/licel/jcardsim/crypto/DSAKeyImpl.java
+++ b/src/main/java/com/licel/jcardsim/crypto/DSAKeyImpl.java
@@ -29,7 +29,7 @@ import org.bouncycastle.crypto.params.DSAValidationParameters;
 
 /**
  * Base class for <code>DSAPublicKeyImpl/DSAPrivateKeyImpl</code>
- * on BouncyCastle CryptoAPI
+ * on BouncyCastle CryptoAPI.
  * @see DSAKey
  */
 public class DSAKeyImpl extends KeyImpl implements DSAKey {

--- a/src/main/java/com/licel/jcardsim/crypto/DSAPrivateKeyImpl.java
+++ b/src/main/java/com/licel/jcardsim/crypto/DSAPrivateKeyImpl.java
@@ -24,7 +24,7 @@ import org.bouncycastle.crypto.params.DSAPrivateKeyParameters;
 
 /**
  * Implementation <code>DSAPrivateKey</code> based
- * on BouncyCastle CryptoAPI
+ * on BouncyCastle CryptoAPI.
  * @see DSAPrivateKey
  * @see DSAPrivateKeyParameters
  */

--- a/src/main/java/com/licel/jcardsim/crypto/DSAPublicKeyImpl.java
+++ b/src/main/java/com/licel/jcardsim/crypto/DSAPublicKeyImpl.java
@@ -24,7 +24,7 @@ import org.bouncycastle.crypto.params.DSAPublicKeyParameters;
 
 /**
  * Implementation <code>DSAPublicKey</code> based
- * on BouncyCastle CryptoAPI
+ * on BouncyCastle CryptoAPI.
  * @see DSAPublicKey
  * @see DSAPublicKeyParameters
  */

--- a/src/main/java/com/licel/jcardsim/crypto/ECKeyImpl.java
+++ b/src/main/java/com/licel/jcardsim/crypto/ECKeyImpl.java
@@ -32,7 +32,7 @@ import org.bouncycastle.math.ec.ECCurve;
 
 /**
  * Base class for
- * <code>ECPublicKeyImpl/ECPrivateKeyImpl</code> on BouncyCastle CryptoAPI
+ * <code>ECPublicKeyImpl/ECPrivateKeyImpl</code> on BouncyCastle CryptoAPI.
  *
  * @see ECKey
  */

--- a/src/main/java/com/licel/jcardsim/crypto/ECPrivateKeyImpl.java
+++ b/src/main/java/com/licel/jcardsim/crypto/ECPrivateKeyImpl.java
@@ -22,7 +22,7 @@ import org.bouncycastle.crypto.params.ECPrivateKeyParameters;
 
 /**
  * Implementation <code>ECPrivateKey</code> based
- * on BouncyCastle CryptoAPI
+ * on BouncyCastle CryptoAPI.
  * @see ECPrivateKey
  * @see ECPrivateKeyParameters
  */
@@ -32,7 +32,9 @@ public class ECPrivateKeyImpl extends ECKeyImpl implements ECPrivateKey {
 
     /**
      * Construct not-initialized ecc private key
+     * @param keyType key type
      * @param keySize key size it bits
+     *
      * @see javacard.security.KeyBuilder
      */
     public ECPrivateKeyImpl(byte keyType, short keySize) {

--- a/src/main/java/com/licel/jcardsim/crypto/ECPublicKeyImpl.java
+++ b/src/main/java/com/licel/jcardsim/crypto/ECPublicKeyImpl.java
@@ -24,7 +24,7 @@ import org.bouncycastle.crypto.params.ECPublicKeyParameters;
 
 /**
  * Implementation <code>ECPublicKey</code> based
- * on BouncyCastle CryptoAPI
+ * on BouncyCastle CryptoAPI.
  * @see ECPublicKey
  * @see ECPublicKeyParameters
  */
@@ -34,6 +34,7 @@ public class ECPublicKeyImpl extends ECKeyImpl implements ECPublicKey {
 
     /**
      * Construct not-initialized ecc public key
+     * @param keyType key type
      * @param keySize key size it bits
      * @see javacard.security.KeyBuilder
      */

--- a/src/main/java/com/licel/jcardsim/crypto/KeyAgreementImpl.java
+++ b/src/main/java/com/licel/jcardsim/crypto/KeyAgreementImpl.java
@@ -27,7 +27,7 @@ import org.bouncycastle.crypto.params.ECPublicKeyParameters;
 
 /**
  * Implementation <code>KeyAgreement</code> based
- * on BouncyCastle CryptoAPI
+ * on BouncyCastle CryptoAPI.
  * @see KeyAgreement
  * @see ECDHBasicAgreement
  * @see ECDHCBasicAgreement

--- a/src/main/java/com/licel/jcardsim/crypto/KeyImpl.java
+++ b/src/main/java/com/licel/jcardsim/crypto/KeyImpl.java
@@ -18,7 +18,7 @@ package com.licel.jcardsim.crypto;
 import javacard.security.Key;
 
 /**
- * Base class for all <code>Key</code> instances
+ * Base class for all <code>Key</code> instances.
  * @see Key
  */
 public abstract class KeyImpl implements Key, KeyWithParameters {

--- a/src/main/java/com/licel/jcardsim/crypto/KeyPairImpl.java
+++ b/src/main/java/com/licel/jcardsim/crypto/KeyPairImpl.java
@@ -30,7 +30,7 @@ import org.bouncycastle.crypto.generators.RSAKeyPairGenerator;
 
 /**
  * Implementation
- * <code>KeyPair</code> based on BouncyCastle CryptoAPI
+ * <code>KeyPair</code> based on BouncyCastle CryptoAPI.
  *
  * @see KeyPair
  * @see RSAKeyPairGenerator
@@ -62,7 +62,7 @@ public final class KeyPairImpl {
      * p, q and g parameters of the public key object are pre-initialized, they
      * will be retained. Otherwise, default precomputed parameter sets will be
      * used. The required default precomputed values are listed in </em>Appendix
-     * B<em> of </em>Java Cryptography Architecture API Specification &
+     * B<em> of </em>Java Cryptography Architecture API Specification &amp;
      * Reference<em> document.</em> <li><em>For the EC case, if the Field, A, B,
      * G and R parameters of the key pair are pre-initialized, then they will be
      * retained. Otherwise default pre-specified values MAY be used (e.g. WAP
@@ -104,9 +104,10 @@ public final class KeyPairImpl {
      * (example -
      * <code>RSAPublicKey</code> interface for the public key and
      * <code>RSAPrivateKey</code> interface for the private key within an
-     * <code>ALG_RSA</code> key pair).<p> <p>Notes:<ul> <li><em>The key objects
+     * <code>ALG_RSA</code> key pair).
+     * <p>Notes:</p> <p><em>The key objects
      * encapsulated in the generated </em><code>KeyPair</code><em> object need
-     * not support the </em><code>KeyEncryption</code><em> interface.</em> </ul>
+     * not support the </em><code>KeyEncryption</code><em> interface.</em></p>
      *
      * @param algorithm the type of algorithm whose key pair needs to be
      * generated. Valid codes listed in <code>ALG_..</code> constants above.

--- a/src/main/java/com/licel/jcardsim/crypto/KeyWithParameters.java
+++ b/src/main/java/com/licel/jcardsim/crypto/KeyWithParameters.java
@@ -20,7 +20,7 @@ import org.bouncycastle.crypto.CipherParameters;
 import org.bouncycastle.crypto.KeyGenerationParameters;
 
 /**
- *
+ * KeyWithParameters.
  */
 public interface KeyWithParameters {
 
@@ -33,7 +33,7 @@ public interface KeyWithParameters {
 
     /**
      * Get keypair generation parameters for use with BouncyCastle Crypto API
-     *
+     * @param rnd Secure Random Generator
      * @return key parameters
      */
     public KeyGenerationParameters getKeyGenerationParameters(SecureRandom rnd);

--- a/src/main/java/com/licel/jcardsim/crypto/MessageDigestImpl.java
+++ b/src/main/java/com/licel/jcardsim/crypto/MessageDigestImpl.java
@@ -31,7 +31,7 @@ import org.bouncycastle.crypto.util.Pack;
 /**
  * Implementation
  * <code>MessageDigest</code> based
- * on BouncyCastle CryptoAPI
+ * on BouncyCastle CryptoAPI.
  * @see MessageDigest
  * @see MD5Digest
  * @see RIPEMD160Digest

--- a/src/main/java/com/licel/jcardsim/crypto/RSAKeyImpl.java
+++ b/src/main/java/com/licel/jcardsim/crypto/RSAKeyImpl.java
@@ -28,7 +28,7 @@ import org.bouncycastle.crypto.params.RSAKeyParameters;
 
 /**
  * Implementation
- * <code>RSAPublic/RSAPrivate</code> based on BouncyCastle CryptoAPI
+ * <code>RSAPublic/RSAPrivate</code> based on BouncyCastle CryptoAPI.
  *
  * @see RSAPrivateKey
  * @see RSAPublicKey

--- a/src/main/java/com/licel/jcardsim/crypto/RSAPrivateCrtKeyImpl.java
+++ b/src/main/java/com/licel/jcardsim/crypto/RSAPrivateCrtKeyImpl.java
@@ -24,7 +24,7 @@ import org.bouncycastle.crypto.params.RSAPrivateCrtKeyParameters;
 
 /**
  * Implementation <code>RSAPrivateCrtKey</code> based
- * on BouncyCastle CryptoAPI
+ * on BouncyCastle CryptoAPI.
  * @see RSAPrivateCrtKey
  * @see RSAPrivateCrtKeyParameters
  */

--- a/src/main/java/com/licel/jcardsim/crypto/RandomDataImpl.java
+++ b/src/main/java/com/licel/jcardsim/crypto/RandomDataImpl.java
@@ -24,7 +24,7 @@ import org.bouncycastle.crypto.prng.RandomGenerator;
 
 /**
  * Implementation <code>RandomData</code> based
- * on BouncyCastle CryptoAPI
+ * on BouncyCastle CryptoAPI.
  * @see RandomData
  */
 public class RandomDataImpl extends RandomData {

--- a/src/main/java/com/licel/jcardsim/crypto/SymmetricCipherImpl.java
+++ b/src/main/java/com/licel/jcardsim/crypto/SymmetricCipherImpl.java
@@ -30,7 +30,7 @@ import org.bouncycastle.crypto.params.ParametersWithIV;
 
 /**
  * Implementation <code>Cipher</code> with symmetric keys based
- * on BouncyCastle CryptoAPI
+ * on BouncyCastle CryptoAPI.
  * @see Cipher
  */
 public class SymmetricCipherImpl extends Cipher {

--- a/src/main/java/com/licel/jcardsim/crypto/SymmetricKeyImpl.java
+++ b/src/main/java/com/licel/jcardsim/crypto/SymmetricKeyImpl.java
@@ -31,7 +31,7 @@ import org.bouncycastle.crypto.engines.DESedeEngine;
 import org.bouncycastle.crypto.params.KeyParameter;
 
 /**
- * Implementation of secret key
+ * Implementation of secret key.
  * @see DESKey
  * @see AESKey
  */

--- a/src/main/java/com/licel/jcardsim/crypto/SymmetricSignatureImpl.java
+++ b/src/main/java/com/licel/jcardsim/crypto/SymmetricSignatureImpl.java
@@ -40,7 +40,7 @@ import org.bouncycastle.crypto.params.ParametersWithIV;
 /**
  * Implementation
  * <code>Signature</code> with symmetric keys based
- * on BouncyCastle CryptoAPI
+ * on BouncyCastle CryptoAPI.
  * @see Signature
  */
 public class SymmetricSignatureImpl extends Signature {

--- a/src/main/java/com/licel/jcardsim/crypto/package-info.java
+++ b/src/main/java/com/licel/jcardsim/crypto/package-info.java
@@ -1,4 +1,4 @@
 /**
- * jCardSim crypto-support classes
+ * jCardSim cryptography support classes
  */
 package com.licel.jcardsim.crypto;

--- a/src/main/java/com/licel/jcardsim/io/CAD.java
+++ b/src/main/java/com/licel/jcardsim/io/CAD.java
@@ -20,7 +20,7 @@ import com.licel.jcardsim.remote.JavaCardRemoteClient;
 import java.util.Properties;
 
 /**
- * Card Acceptance Device (CAD)
+ * Card Acceptance Device (CAD).
  *
  * @author LICEL LLC
  */

--- a/src/main/java/com/licel/jcardsim/io/CardInterface.java
+++ b/src/main/java/com/licel/jcardsim/io/CardInterface.java
@@ -16,7 +16,7 @@
 package com.licel.jcardsim.io;
 
 /**
- * Basic SmartCard Interface
+ * Basic SmartCard Interface.
  *
  * @author LICEL LLC
  */
@@ -29,6 +29,7 @@ public interface CardInterface {
 
     /**
      * Returns ATR
+     * @return ATR bytes
      */
     public byte[] getATR();
 

--- a/src/main/java/com/licel/jcardsim/io/JavaCardInterface.java
+++ b/src/main/java/com/licel/jcardsim/io/JavaCardInterface.java
@@ -19,7 +19,7 @@ import javacard.framework.AID;
 import javacard.framework.SystemException;
 
 /**
- * Interface with JavaCard-specific functions
+ * Interface with JavaCard-specific functions.
  * @author LICEL LLC
  */
 public interface JavaCardInterface extends CardInterface {

--- a/src/main/java/com/licel/jcardsim/io/JavaxSmartCardInterface.java
+++ b/src/main/java/com/licel/jcardsim/io/JavaxSmartCardInterface.java
@@ -22,7 +22,7 @@ import javax.smartcardio.CommandAPDU;
 import javax.smartcardio.ResponseAPDU;
 
 /**
- * Simulator with javacardx.smartcardio Command/Response support
+ * Simulator with javacardx.smartcardio Command/Response support.
  */
 public class JavaxSmartCardInterface extends Simulator {
     /**

--- a/src/main/java/com/licel/jcardsim/io/package-info.java
+++ b/src/main/java/com/licel/jcardsim/io/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * jCardSim I/O support classes
+ */
+package com.licel.jcardsim.io;

--- a/src/main/java/com/licel/jcardsim/remote/BixVReaderCard.java
+++ b/src/main/java/com/licel/jcardsim/remote/BixVReaderCard.java
@@ -23,7 +23,7 @@ import java.util.Enumeration;
 import java.util.Properties;
 
 /**
- * BixVReader Card Implementation
+ * BixVReader Card Implementation.
  * 
  * @author LICEL LLC
  */

--- a/src/main/java/com/licel/jcardsim/remote/BixVReaderIPCProtocol.java
+++ b/src/main/java/com/licel/jcardsim/remote/BixVReaderIPCProtocol.java
@@ -20,8 +20,10 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 
 /**
- * Client protocol impl (BixVReader (IPC))
- * http://www.codeproject.com/Articles/134010/An-UMDF-Driver-for-a-Virtual-Smart-Card-Reader
+ * Client protocol impl (BixVReader (IPC)).
+ *
+ * See <a href="http://www.codeproject.com/Articles/134010/An-UMDF-Driver-for-a-Virtual-Smart-Card-Reader"
+ * >http://www.codeproject.com/Articles/134010/An-UMDF-Driver-for-a-Virtual-Smart-Card-Reader</a>
  *
  * @author LICEL LLC
  */

--- a/src/main/java/com/licel/jcardsim/remote/JavaCardRemoteClient.java
+++ b/src/main/java/com/licel/jcardsim/remote/JavaCardRemoteClient.java
@@ -24,7 +24,7 @@ import javacard.framework.AID;
 import javacard.framework.SystemException;
 
 /**
- * RMI client
+ * RMI client.
  *
  * @author LICEL LLC
  */

--- a/src/main/java/com/licel/jcardsim/remote/JavaCardRemoteInterface.java
+++ b/src/main/java/com/licel/jcardsim/remote/JavaCardRemoteInterface.java
@@ -19,7 +19,7 @@ import java.rmi.Remote;
 import java.rmi.RemoteException;
 
 /**
- * RMI Wrapper for the <code>JavaCardInterface</code>
+ * RMI Wrapper for the <code>JavaCardInterface</code>.
  * 
  * @author LICEL LLC
  */

--- a/src/main/java/com/licel/jcardsim/remote/JavaCardRemoteServer.java
+++ b/src/main/java/com/licel/jcardsim/remote/JavaCardRemoteServer.java
@@ -24,7 +24,7 @@ import java.util.Enumeration;
 import java.util.Properties;
 
 /**
- * RMI Server
+ * RMI Server.
  * @author LICEL LLC
  */
 public class JavaCardRemoteServer extends java.rmi.server.UnicastRemoteObject

--- a/src/main/java/com/licel/jcardsim/remote/SerializableAID.java
+++ b/src/main/java/com/licel/jcardsim/remote/SerializableAID.java
@@ -19,7 +19,7 @@ import java.io.Serializable;
 import javacard.framework.AID;
 
 /**
- * Serializable AID container for the RMI calls
+ * Serializable AID container for the RMI calls.
  *
  * @author LICEL LLC
  */

--- a/src/main/java/com/licel/jcardsim/samples/BaseApplet.java
+++ b/src/main/java/com/licel/jcardsim/samples/BaseApplet.java
@@ -18,7 +18,7 @@ package com.licel.jcardsim.samples;
 import javacard.framework.Applet;
 
 /**
- * Base class
+ * Base class.
  * @author LICEL LLC
  */
 

--- a/src/main/java/com/licel/jcardsim/samples/DualInterfaceApplet.java
+++ b/src/main/java/com/licel/jcardsim/samples/DualInterfaceApplet.java
@@ -19,9 +19,9 @@ import javacard.framework.*;
 
 
 /**
- * Dual interface applet
+ * Dual interface applet.
  *
- * Supported APDUs:
+ * <p>Supported APDUs:</p>
  *
  * <ul>
  *     <li><code>CLA=0x80 INS=0</code> read value</li>

--- a/src/main/java/com/licel/jcardsim/samples/HelloWorldApplet.java
+++ b/src/main/java/com/licel/jcardsim/samples/HelloWorldApplet.java
@@ -18,7 +18,7 @@ package com.licel.jcardsim.samples;
 import javacard.framework.*;
 
 /**
- * Basic HelloWorld JavaCard Applet
+ * Basic HelloWorld JavaCard Applet.
  * @author LICEL LLC
  */
 public class HelloWorldApplet extends BaseApplet {
@@ -70,6 +70,9 @@ public class HelloWorldApplet extends BaseApplet {
 
     /**
      * Only this class's install method should create the applet object.
+     * @param bArray the array containing installation parameters
+     * @param bOffset the starting offset in bArray
+     * @param bLength the length in bytes of the parameter data in bArray
      */
     protected HelloWorldApplet(byte[] bArray, short bOffset, byte bLength) {
         echoBytes = new byte[LENGTH_ECHO_BYTES];
@@ -88,10 +91,10 @@ public class HelloWorldApplet extends BaseApplet {
 
     /**
      * This method is called once during applet instantiation process.
-     * @param bArray
-     * @param bOffset
-     * @param bLength
-     * @throws ISOException
+     * @param bArray the array containing installation parameters
+     * @param bOffset the starting offset in bArray
+     * @param bLength the length in bytes of the parameter data in bArray
+     * @throws ISOException if the install method failed
      */
     public static void install(byte[] bArray, short bOffset, byte bLength)
             throws ISOException {

--- a/src/main/java/com/licel/jcardsim/samples/MultiInstanceApplet.java
+++ b/src/main/java/com/licel/jcardsim/samples/MultiInstanceApplet.java
@@ -18,11 +18,11 @@ package com.licel.jcardsim.samples;
 import javacard.framework.*;
 
 /**
- * Multi instance sample applet
+ * Multi instance sample applet.
  *
- * Returns <code>FCI</code> (file control information) on SELECT
+ * <p>Returns <code>FCI</code> (file control information) on SELECT</p>
  *
- * Supported APDUs:
+ * <p>Supported APDUs:</p>
  *
  * <ul>
  *     <li><code>CLA=0x80 INS=0</code> return AID</li>

--- a/src/main/java/com/licel/jcardsim/samples/Sha1Applet.java
+++ b/src/main/java/com/licel/jcardsim/samples/Sha1Applet.java
@@ -21,9 +21,9 @@ import javacardx.apdu.ExtendedLength;
 
 
 /**
- * Applet for calculating SHA1 digests
+ * Applet for calculating SHA1 digests.
  *
- * Supported APDUs:
+ * <p>Supported APDUs:</p>
  *
  * <ul>
  *     <li><code>CLA=0x80 INS=0</code> digest of <code>CData</code></li>

--- a/src/main/java/com/licel/jcardsim/smartcardio/JCSCard.java
+++ b/src/main/java/com/licel/jcardsim/smartcardio/JCSCard.java
@@ -60,8 +60,6 @@ public class JCSCard extends Card {
 
     /**
      * Always returns basic channel with id = 0
-     *
-     * @throws CardException
      */
     public CardChannel openLogicalChannel() throws CardException {
         return basicChannel;

--- a/src/main/java/com/licel/jcardsim/smartcardio/package-info.java
+++ b/src/main/java/com/licel/jcardsim/smartcardio/package-info.java
@@ -1,4 +1,4 @@
 /**
- * jCardSim <code>javax.smartcardio</code> Provider
+ * jCardSim <code>javax.smartcardio</code> provider
  */
 package com.licel.jcardsim.smartcardio;

--- a/src/main/java/com/licel/jcardsim/utils/AIDUtil.java
+++ b/src/main/java/com/licel/jcardsim/utils/AIDUtil.java
@@ -22,7 +22,7 @@ import org.bouncycastle.util.encoders.Hex;
 import java.util.Comparator;
 
 /**
- * Utility methods for dealing with AIDs
+ * Utility methods for dealing with AIDs.
  */
 public final class AIDUtil {
     private static final Comparator<AID> aidComparator = new Comparator<AID>() {

--- a/src/main/java/com/licel/jcardsim/utils/BiConsumer.java
+++ b/src/main/java/com/licel/jcardsim/utils/BiConsumer.java
@@ -1,7 +1,7 @@
 package com.licel.jcardsim.utils;
 
 /**
- * Back-port of Java 8 {@code java.util.function.BiConsumer}
+ * Back-port of Java 8 <code>java.util.function.BiConsumer</code>.
  */
 public interface BiConsumer<T,U> {
     void accept(T t, U u);

--- a/src/main/java/com/licel/jcardsim/utils/ByteUtil.java
+++ b/src/main/java/com/licel/jcardsim/utils/ByteUtil.java
@@ -18,7 +18,7 @@ package com.licel.jcardsim.utils;
 import org.bouncycastle.util.encoders.Hex;
 
 /**
- * Utility methods for dealing with byte arrays
+ * Utility methods for dealing with byte arrays.
  */
 public final class ByteUtil {
     private static final char[] hexArray = "0123456789ABCDEF".toCharArray();

--- a/src/main/java/javacard/framework/AID.java
+++ b/src/main/java/javacard/framework/AID.java
@@ -96,7 +96,7 @@ public class AID {
      * This method does not throw <code>NullPointerException</code>.
      * @param anObject the object to compare <code>this</code> <code>AID</code> against
      * @return <code>true</code> if the AID byte values are equal, <code>false</code> otherwise
-     * @throws SecurityException <if <code>anObject</code> object is not accessible in the caller's context
+     * @throws SecurityException if <code>anObject</code> object is not accessible in the caller's context
      */
     public final boolean equals(Object anObject)
             throws SecurityException {

--- a/src/main/java/javacard/framework/APDU.java
+++ b/src/main/java/javacard/framework/APDU.java
@@ -57,7 +57,7 @@ import java.util.Arrays;
  * 
  * For sending large byte arrays as response data,
  * the <code>APDU</code> class provides a special method <code>sendBytesLong()</code> which
- * manages the APDU buffer.<p>
+ * manages the APDU buffer.
  * 
  * <pre>
  * // The purpose of this example is to show most of the methods
@@ -73,11 +73,11 @@ import java.util.Arrays;
  * ...
  * // assume this command has incoming data
  * // Lc tells us the incoming apdu command length
- * short bytesLeft = (short) (buffer[ISO7816.OFFSET_LC] & 0x00FF);
- * if (bytesLeft < (short)55) ISOException.throwIt( ISO7816.SW_WRONG_LENGTH );
+ * short bytesLeft = (short) (buffer[ISO7816.OFFSET_LC] &amp; 0x00FF);
+ * if (bytesLeft &lt; (short)55) ISOException.throwIt( ISO7816.SW_WRONG_LENGTH );
  * 
  * short readCount = apdu.setIncomingAndReceive();
- * while ( bytesLeft > 0){
+ * while ( bytesLeft &gt; 0){
  * // process bytes in buffer[5] to buffer[readCount+4];
  * bytesLeft -= readCount;
  * readCount = apdu.receiveBytes ( ISO7816.OFFSET_CDATA );
@@ -86,12 +86,12 @@ import java.util.Arrays;
  * //...
  * //
  * // Note that for a short response as in the case illustrated here
- * // the three APDU method calls shown : setOutgoing(),setOutgoingLength() & sendBytes()
+ * // the three APDU method calls shown : setOutgoing(),setOutgoingLength() &amp; sendBytes()
  * // could be replaced by one APDU method call : setOutgoingAndSend().
  * 
  * // construct the reply APDU
  * short le = apdu.setOutgoing();
- * if (le < (short)2) ISOException.throwIt( ISO7816.SW_WRONG_LENGTH );
+ * if (le &lt; (short)2) ISOException.throwIt( ISO7816.SW_WRONG_LENGTH );
  * apdu.setOutgoingLength( (short)3 );
  * 
  * // build response data in apdu.buffer[ 0.. outCount-1 ];
@@ -109,8 +109,8 @@ import java.util.Arrays;
  * <code>getCurrentState()</code> method returns the current state.
  * <p>
  * Note that the state number assignments are ordered as follows:
- * STATE_INITIAL < STATE_PARTIAL_INCOMING < STATE_FULL_INCOMING <
- * STATE_OUTGOING < STATE_OUTGOING_LENGTH_KNOWN < STATE_PARTIAL_OUTGOING <
+ * STATE_INITIAL &lt; STATE_PARTIAL_INCOMING &lt; STATE_FULL_INCOMING &lt;
+ * STATE_OUTGOING &lt; STATE_OUTGOING_LENGTH_KNOWN &lt; STATE_PARTIAL_OUTGOING &lt;
  * STATE_FULL_OUTGOING.
  * <p>
  * The following are processing error states and have negative state number
@@ -286,10 +286,10 @@ public final class APDU {
     /**
      * Returns the APDU buffer byte array.
      * <p>Note:<ul>
-     * <li><em>References to the APDU buffer byte array
+     * <li>References to the APDU buffer byte array
      * cannot be stored in class variables or instance variables or array components.
      * See <em>Runtime
-     * Specification for the Java Card Platform</em>, section 6.2.2 for details.</em>
+     * Specification for the Java Card Platform</em>, section 6.2.2 for details.
      * </ul>
      * @return byte array containing the APDU buffer
      */
@@ -383,6 +383,7 @@ public final class APDU {
      * @throws APDUException with the following reason codes:<ul>
      * <li><code>APDUException.ILLEGAL_USE</code> if this method, or <code>setOutgoingNoChaining()</code> method already invoked.
      * <li><code>APDUException.IO_ERROR</code> on I/O error.
+     * </ul>
      */
     public short setOutgoing()
             throws APDUException {
@@ -425,6 +426,7 @@ public final class APDU {
      * @throws APDUException with the following reason codes:<ul>
      * <li><code>APDUException.ILLEGAL_USE</code> if this method, or <code>setOutgoingNoChaining()</code> method already invoked.
      * <li><code>APDUException.IO_ERROR</code> on I/O error.
+     * </ul>
      */
     public short setOutgoingNoChaining()
             throws APDUException {
@@ -441,7 +443,7 @@ public final class APDU {
      * Sets the actual length of response data. If a length of
      * <code>0</code> is specified, no data will be output.
      * <p>Note:<ul>
-     * <li><em>In T=0 (Case 2&4) protocol, the length is used by the Java Card runtime environment to prompt the CAD for GET RESPONSE commands.</em>
+     * <li><em>In T=0 (Case 2&amp;4) protocol, the length is used by the Java Card runtime environment to prompt the CAD for GET RESPONSE commands.</em>
      * <li><em>This method sets the state of the
      * <code>APDU</code> object to
      * <code>STATE_OUTGOING_LENGTH_KNOWN</code>.</em>
@@ -464,6 +466,7 @@ public final class APDU {
      * is in use and the CAD does not respond to <code>(ISO7816.SW_CORRECT_LENGTH_00+count)</code> response status by re-issuing same APDU command on the same origin 
      * logical channel number as that of the current APDU command with the corrected length. 
      * <li><code>APDUException.IO_ERROR</code> on I/O error.
+     * </ul>
      * @see #getOutBlockSize()
      */
     public void setOutgoingLength(short len)
@@ -526,7 +529,7 @@ public final class APDU {
      * This method should only be called on a case 3 or case 4 command, otherwise erroneous behavior may result.
      * <p>Notes:
      * <ul>
-     * <li><em>In T=0 ( Case 3&4 ) protocol, the P3 param is assumed to be Lc.</em>
+     * <li><em>In T=0 ( Case 3&amp;4 ) protocol, the P3 param is assumed to be Lc.</em>
      * <li><em>Data is read into the buffer at offset 5 for normal APDU semantics.</em>
      * <li><em>Data is read into the buffer at offset 7 for an extended length APDU (Case 3E/4E).</em>
      * <li><em>In T=1 protocol, if all the incoming bytes do not fit in the buffer, this method may

--- a/src/main/java/javacard/framework/APDUException.java
+++ b/src/main/java/javacard/framework/APDUException.java
@@ -50,7 +50,7 @@ public class APDUException extends CardRuntimeException {
     public static final short IO_ERROR = 4;
     /**
      * This reason code indicates that during T=0 protocol, the CAD did not return a GET RESPONSE
-     * command in response to a <61xx> response status to send additional data. The outgoing
+     * command in response to a &lt;61xx&gt; response status to send additional data. The outgoing
      * transfer has been aborted. No more data or status can be sent to the CAD
      * in this <code>Applet.process()</code> method.
      */
@@ -65,7 +65,7 @@ public class APDUException extends CardRuntimeException {
     public static final short T1_IFD_ABORT = 171;
     /**
      * This reason code indicates that during T=0 protocol, the CAD did not reissue the
-     * same APDU command with the corrected length in response to a <6Cxx> response status
+     * same APDU command with the corrected length in response to a &lt;6Cxx&gt; response status
      * to request command reissue with the specified length. The outgoing
      * transfer has been aborted. No more data or status can be sent to the CAD
      * in this <code>Applet.process()</code> method

--- a/src/main/java/javacard/framework/Applet.java
+++ b/src/main/java/javacard/framework/Applet.java
@@ -67,7 +67,7 @@ import com.licel.jcardsim.utils.BiConsumer;
  *             // send response data to select command
  *             short Le =  apdu.setOutgoing();
  *             // assume data containing response bytes in replyData[] array.
- *             if ( Le < ..) ISOException.throwIt( ISO7816.SW_WRONG_LENGTH);
+ *             if ( Le &lt; ..) ISOException.throwIt( ISO7816.SW_WRONG_LENGTH);
  *             apdu.setOutgoingLength( (short)replyData.length );
  *             apdu.sendBytesLong(replyData, (short) 0, (short)replyData.length);
  *             break;

--- a/src/main/java/javacard/framework/ISO7816.java
+++ b/src/main/java/javacard/framework/ISO7816.java
@@ -21,7 +21,7 @@ package javacard.framework;
  * <code>ISO7816</code> interface contains only static fields.<p>
  * The static fields with <code>SW_</code> prefixes define constants for the ISO 7816-4 defined response
  * status word. The fields which use the <code>_00</code> suffix require the low order byte to be
- * customized appropriately e.g (ISO7816.SW_CORRECT_LENGTH_00 + (0x0025 & 0xFF)).<p>
+ * customized appropriately e.g (ISO7816.SW_CORRECT_LENGTH_00 + (0x0025 &amp; 0xFF)).<p>
  * The static fields with <code>OFFSET_</code> prefixes define constants to be used to index into
  * the APDU buffer byte array to access ISO 7816-4 defined header information.
  *
@@ -37,7 +37,7 @@ public interface ISO7816
      */
     public static final short SW_BYTES_REMAINING_00 = 24832;
     /**
-     * >Response status : Wrong length = 0x6700
+     * Response status : Wrong length = 0x6700
      */
     public static final short SW_WRONG_LENGTH = 26368;
     /**

--- a/src/main/java/javacard/framework/JCSystem.java
+++ b/src/main/java/javacard/framework/JCSystem.java
@@ -41,7 +41,6 @@ import com.licel.jcardsim.base.SimulatorSystem;
  * is written or nothing at all is written.
  * The <code>JCSystem</code> includes methods to control an atomic transaction.
  * See <em>Runtime Environment Specification for the Java Card Platform</em> for details.
- * <p>
  *
  */
 public final class JCSystem {
@@ -87,8 +86,8 @@ public final class JCSystem {
      * Checks if the specified object is transient.
      * <p>Note:
      * <ul>
-     * <em>This method returns </em><code>NOT_A_TRANSIENT_OBJECT</code><em> if the specified object is
-     * <code>null</code> or is not an array type.</em>
+     * <li><em>This method returns </em><code>NOT_A_TRANSIENT_OBJECT</code><em> if the specified object is
+     * <code>null</code> or is not an array type.</em></li>
      * </ul>
      * @param theObj the object being queried
      * @return <code>NOT_A_TRANSIENT_OBJECT</code>, <code>CLEAR_ON_RESET</code>, or <code>CLEAR_ON_DESELECT</code>
@@ -438,6 +437,7 @@ public final class JCSystem {
      * @throws SystemException with the following reason codes:<ul>
      * <li><code>SystemException.ILLEGAL_USE</code> if the object deletion mechanism is
      * not implemented.
+     * </ul>
      */
     public static void requestObjectDeletion()
             throws SystemException {

--- a/src/main/java/javacard/framework/MultiSelectable.java
+++ b/src/main/java/javacard/framework/MultiSelectable.java
@@ -63,6 +63,7 @@ public interface MultiSelectable
      *  </ul>
      * @param appInstAlreadyActive boolean flag is <code>true</code> when the same applet
      * instance is already active on another logical channel and <code>false</code> otherwise
+     * @return <code>true</code> to indicate success, <code>false</code> otherwise
      */
     public abstract boolean select(boolean appInstAlreadyActive);
 

--- a/src/main/java/javacard/framework/OwnerPIN.java
+++ b/src/main/java/javacard/framework/OwnerPIN.java
@@ -59,8 +59,8 @@ public class OwnerPIN implements PIN {
     /**
      * Constructor. Allocates a new <code>PIN</code> instance with validated flag
      * set to <code>false</code>
-     * @param tryLimit the maximum number of times an incorrect PIN can be presented. <code>tryLimit</code> must be >=1
-     * @param maxPINSize the maximum allowed PIN size. <code>maxPINSize</code> must be >=1
+     * @param tryLimit the maximum number of times an incorrect PIN can be presented. <code>tryLimit</code> must be &gt;=1
+     * @param maxPINSize the maximum allowed PIN size. <code>maxPINSize</code> must be &gt;=1
      * @throws PINException with the following reason codes:
      * <ul>
      *  <li><code>PINException.ILLEGAL_VALUE</code> if <code>tryLimit</code> parameter is less than 1.

--- a/src/main/java/javacard/framework/Util.java
+++ b/src/main/java/javacard/framework/Util.java
@@ -47,7 +47,7 @@ public class Util {
      * <li><em>If </em><code>destOff+length</code><em> is greater than </em><code>dest.length</code><em>, the length
      *     of the </em><code>dest</code><em> array an </em><code>ArrayIndexOutOfBoundsException</code><em> exception is thrown
      *     and no copy is performed.</em></li>
-     * <li><em>If </em><code>src</code><em> or </em><code>dest</code><em> parameter is </em><code>null</code><em></li>
+     * <li><em>If </em><code>src</code><em> or </em><code>dest</code><em> parameter is </em><code>null</code><em>
      *     a </em><code>NullPointerException</code><em> exception is thrown.</em></li>
      * <li><em>If the <code>src</code> and <code>dest</code> arguments refer to the same array object,
      *     then the copying is performed as if the components at positions </em><code>srcOff</code><em>

--- a/src/main/java/javacard/security/AESKey.java
+++ b/src/main/java/javacard/security/AESKey.java
@@ -19,8 +19,7 @@ package javacard.security;
 /**
  * <code>AESKey</code> contains a 16/24/32 byte key for AES computations based
  * on the Rijndael algorithm.
- * <p>When the key data is set, the key is initialized and ready for use.
- * <p>
+ * <p>When the key data is set, the key is initialized and ready for use.</p>
  * @see KeyBuilder
  * @see Signature
  * @see javacardx.crypto.Cipher

--- a/src/main/java/javacard/security/DSAKey.java
+++ b/src/main/java/javacard/security/DSAKey.java
@@ -17,13 +17,13 @@
 package javacard.security;
 
 /**
- * The </code>DSAKey</code> interface is the base interface for the DSA algorithm's private and
+ * The <code>DSAKey</code> interface is the base interface for the DSA algorithm's private and
  * public key implementations. A DSA private key implementation must also implement
  * the <code>DSAPrivateKey</code> interface methods. A DSA public key implementation must also implement
  * the <code>DSAPublicKey</code> interface methods.
  * <p>When all four components of the key (X or Y,P,Q,G) are set, the key is
- * initialized and ready for use.
- * <p>
+ * initialized and ready for use.</p>
+ *
  * @see DSAPublicKey
  * @see DSAPrivateKey
  * @see KeyBuilder

--- a/src/main/java/javacard/security/DSAPrivateKey.java
+++ b/src/main/java/javacard/security/DSAPrivateKey.java
@@ -23,7 +23,7 @@ package javacard.security;
  * the <code>DSAKey</code> interface methods.
  * <p>When all four components of the key (X,P,Q,G) are set, the key is
  * initialized and ready for use.
- * <p>
+ *
  * @see DSAPublicKey
  * @see KeyBuilder
  * @see Signature

--- a/src/main/java/javacard/security/ECKey.java
+++ b/src/main/java/javacard/security/ECKey.java
@@ -71,12 +71,12 @@ public interface ECKey {
      * of type <CODE>TYPE_EC_F2M_PUBLIC</CODE> or <CODE>TYPE_EC_F2M_PRIVATE</CODE> in
      * the case where the polynomial is a trinomial, of the form
      * x^n + x^e + 1 (where n is the bit length of the key).
-     * It is required that n > e > 0.
+     * It is required that n &gt; e &gt; 0.
      * @param e the value of the intermediate exponent of the trinomial
      * @throws CryptoException with the following reason codes:
      * <ul>
      * <li><code>CryptoException.ILLEGAL_VALUE</code> if the input parameter e
-     * is not such that 0 < e < n.
+     * is not such that 0 &lt; e &lt; n.
      * <li><code>CryptoException.NO_SUCH_ALGORITHM</code> if the key is neither
      * of type <code>TYPE_EC_F2M_PUBLIC</code> nor <code>TYPE_EC_F2M_PRIVATE</code>. </ul>
      */
@@ -88,7 +88,7 @@ public interface ECKey {
      * of type <CODE>TYPE_EC_F2M_PUBLIC</CODE> or <CODE>TYPE_EC_F2M_PRIVATE</CODE> in
      * the case where the polynomial is a pentanomial, of the form
      * x^n + x^e1 + x^e2 + x^e3 + 1 (where n is the bit length of the key).
-     * It is required for all ei where ei = {e1, e2, e3} that n > ei > 0.
+     * It is required for all ei where ei = {e1, e2, e3} that n &gt; ei &gt; 0.
      * @param e1 the value of the first of the intermediate exponents of the
      * pentanomial
      * @param e2 the value of the second of the intermediate exponent of the
@@ -98,7 +98,7 @@ public interface ECKey {
      * <ul>
      * <li><code>CryptoException.ILLEGAL_VALUE</code> if the input parameters
      * ei where ei = {<code>e1</code>, <code>e2</code>, <code>e3</code>}
-     * are not such that for all ei, n > ei > 0.
+     * are not such that for all ei, n &gt; ei &gt; 0.
      * <li><code>CryptoException.NO_SUCH_ALGORITHM</code> if the key is neither
      * of type <code>TYPE_EC_F2M_PUBLIC</code> nor <code>TYPE_EC_F2M_PRIVATE</code>.
      * </ul>

--- a/src/main/java/javacard/security/HMACKey.java
+++ b/src/main/java/javacard/security/HMACKey.java
@@ -21,11 +21,10 @@ package javacard.security;
  * any length, but it is strongly recommended that the key is not shorter than the
  * byte length of the hash output used in the HMAC implementation.
  * Keys with length greater than the hash block length are first hashed with the
- * hash algorithm used for the HMAC implementation. <p>
+ * hash algorithm used for the HMAC implementation.
  * <p>Implementations must support an HMAC key length equal to the length of
  * the supported hash algorithm block size (e.g 64 bits for SHA-1)
  * <p>When the key data is set, the key is initialized and ready for use.
- * <p>
  * 
  * @see KeyBuilder
  * @see Signature 

--- a/src/main/java/javacard/security/InitializedMessageDigest.java
+++ b/src/main/java/javacard/security/InitializedMessageDigest.java
@@ -38,7 +38,6 @@ public abstract class InitializedMessageDigest extends MessageDigest {
 
     /**
      * protected constructor
-     * <P>
      */
     protected InitializedMessageDigest() {
     }

--- a/src/main/java/javacard/security/Key.java
+++ b/src/main/java/javacard/security/Key.java
@@ -18,7 +18,7 @@ package javacard.security;
 
 /**
  * The <code>Key</code> interface is the base interface for all keys.
- * <p>
+ *
  * <p>A <code>Key</code> object sets its initialized state to true only when all the associated
  * <code>Key</code> object parameters have been set at least once since the time the initialized state was set to false.
  * <p>A newly created <code>Key</code> object sets its initialized state to false. Invocation of the
@@ -43,7 +43,6 @@ public interface Key {
      * Returns the key interface type.
      * @return the key interface type. Valid codes listed in TYPE.. constants
      * See <CODE>KeyBuilder.TYPE_DES_TRANSIENT_RESET</CODE>
-     * <p>
      * @see KeyBuilder
      */
     public abstract byte getType();

--- a/src/main/java/javacard/security/KeyPair.java
+++ b/src/main/java/javacard/security/KeyPair.java
@@ -67,7 +67,7 @@ public final class KeyPair {
      * <li><em>For the DSA algorithm, if the p, q and g parameters of the public key object are pre-initialized,
      * they will be retained. Otherwise, default precomputed parameter sets will be used. The required
      * default precomputed values are listed in </em>Appendix B<em> of </em>Java Cryptography Architecture
-     * API Specification & Reference<em> document.</em>
+     * API Specification &amp; Reference<em> document.</em>
      * <li><em>For the EC case, if the Field, A, B, G and R parameters of the
      * key pair are pre-initialized, then they will be retained. Otherwise
      * default pre-specified values MAY be used (e.g. WAP predefined curves),
@@ -100,7 +100,7 @@ public final class KeyPair {
      * The encapsulated key objects are of the specified <code>keyLength</code> size and
      * implement the appropriate <code>Key</code> interface associated with the specified algorithm
      * (example - <code>RSAPublicKey</code> interface for the public key and <code>RSAPrivateKey</code>
-     * interface for the private key within an <code>ALG_RSA</code> key pair).<p>
+     * interface for the private key within an <code>ALG_RSA</code> key pair).
      * <p>Notes:<ul>
      * <li><em>The key objects encapsulated in the generated </em><code>KeyPair</code><em> object
      * need not support the </em><code>KeyEncryption</code><em> interface.</em>

--- a/src/main/java/javacard/security/Signature.java
+++ b/src/main/java/javacard/security/Signature.java
@@ -100,7 +100,7 @@ public abstract class Signature {
      */
     public static final byte ALG_DES_MAC4_PKCS5 = 7;
     /**
-     * Signature algorithm </code>ALG_DES_MAC8_PKCS5</code> generates an 8-byte MAC
+     * Signature algorithm <code>ALG_DES_MAC8_PKCS5</code> generates an 8-byte MAC
      * using DES in CBC mode or triple DES in outer CBC mode.
      * Input data is padded according to the PKCS#5 scheme.
      * <p>Note:
@@ -141,7 +141,7 @@ public abstract class Signature {
      * and encrypts it using RSA.
      * <p>Note:<ul>
      * <li><em> The encryption block(EB) during signing is built as follows:<br>
-     * <&nbsp; EB = 00 || 01 || PS || 00 || T<br>
+     * &lt;&nbsp; EB = 00 || 01 || PS || 00 || T<br>
      * &nbsp; &nbsp; &nbsp; :: where T is the DER encoding of :<br>
      * &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; digestInfo ::= SEQUENCE {<br>
      * &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; digestAlgorithm AlgorithmIdentifier of MD5,<br>
@@ -166,7 +166,7 @@ public abstract class Signature {
      * and encrypts it using RSA.
      * <p>Note:<ul>
      * <li><em> The encryption block(EB) during signing is built as follows:<br>
-     * <&nbsp; EB = 00 || 01 || PS || 00 || T<br>
+     * &lt;&nbsp; EB = 00 || 01 || PS || 00 || T<br>
      * &nbsp; &nbsp; &nbsp; :: where T is the DER encoding of :<br>
      * &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; digestInfo ::= SEQUENCE {<br>
      * &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; digestAlgorithm AlgorithmIdentifier of RIPEMD160,<br>

--- a/src/main/java/javacard/security/SignatureMessageRecovery.java
+++ b/src/main/java/javacard/security/SignatureMessageRecovery.java
@@ -51,7 +51,7 @@ package javacard.security;
  * <code>verify()</code> method to verify the
  * signature.
  *
- * <p>Note:<br/>
+ * <p>Note:<br>
  * A
  * <code>Signature</code> object implementing this interface must throw
  * <code>CryptoException</code> with

--- a/src/main/java/javacardx/crypto/Cipher.java
+++ b/src/main/java/javacardx/crypto/Cipher.java
@@ -333,11 +333,11 @@ public abstract class Cipher {
      * </em><code>outBuff</code><em>
      * are the same array, then the output data area must not partially overlap the input data area such that
      * the input data is modified before it is used;
-     * if </em><code>inBuff==outBuff</code><em> and<br> </em><code>inOffset < outOffset < inOffset+inLength</code><em>,
+     * if </em><code>inBuff==outBuff</code><em> and<br> </em><code>inOffset &lt; outOffset &lt; inOffset+inLength</code><em>,
      * incorrect output may result.</em>
      * <li><em>When non-block aligned data is presented as input data, no amount of input
      * and output buffer data overlap is allowed;
-     * if </em><code>inBuff==outBuff</code><em> and<br> </em><code>outOffset < inOffset+inLength</code><em>,
+     * if </em><code>inBuff==outBuff</code><em> and<br> </em><code>outOffset &lt; inOffset+inLength</code><em>,
      * incorrect output may result.</em>
      * <li><em>AES, DES, and triple DES algorithms in CBC mode reset the initial vector(IV)
      * to 0. The initial vector(IV) can be re-initialized using the
@@ -396,11 +396,11 @@ public abstract class Cipher {
      * </em><code>outBuff</code><em>
      * are the same array, then the output data area must not partially overlap the input data area such that
      * the input data is modified before it is used;
-     * if </em><code>inBuff==outBuff</code><em> and<br> </em><code>inOffset < outOffset < inOffset+inLength</code><em>,
+     * if </em><code>inBuff==outBuff</code><em> and<br> </em><code>inOffset &lt; outOffset &lt; inOffset+inLength</code><em>,
      * incorrect output may result.</em>
      * <li><em>When non-block aligned data is presented as input data, no amount of input
      * and output buffer data overlap is allowed;
-     * if </em><code>inBuff==outBuff</code><em> and<br> </em><code>outOffset < inOffset+inLength</code><em>,
+     * if </em><code>inBuff==outBuff</code><em> and<br> </em><code>outOffset &lt; inOffset+inLength</code><em>,
      * incorrect output may result.</em>
      * <li><em>On decryption operations(except when ISO 9797 method 1 padding is used),
      * the padding bytes are not written to </em><code>outBuff</code><em>.</em>

--- a/src/main/java/javacardx/crypto/KeyEncryption.java
+++ b/src/main/java/javacardx/crypto/KeyEncryption.java
@@ -19,7 +19,6 @@ package javacardx.crypto;
 /**
  *<code>KeyEncryption</code> interface defines the methods used to enable encrypted
  * key data access to a key implementation.
- *<p>
  */
 public interface KeyEncryption {
 

--- a/src/test/java/com/licel/jcardsim/smartcardio/JCardSimProviderTest.java
+++ b/src/test/java/com/licel/jcardsim/smartcardio/JCardSimProviderTest.java
@@ -95,30 +95,30 @@ public class JCardSimProviderTest extends TestCase {
         response = jcsChannel.transmit(selectApplet);
         assertEquals(response.getSW(), 0x9000);
         // test NOP
-        response = jcsChannel.transmit(new CommandAPDU(0x01, 0x02, 0x00, 0x00));
+        response = jcsChannel.transmit(new CommandAPDU(0x00, 0x02, 0x00, 0x00));
         assertEquals(0x9000, response.getSW());
         // test SW_INS_NOT_SUPPORTED
-        response = jcsChannel.transmit(new CommandAPDU(0x01, 0x05, 0x00, 0x00));
+        response = jcsChannel.transmit(new CommandAPDU(0x00, 0x05, 0x00, 0x00));
         assertEquals(ISO7816.SW_INS_NOT_SUPPORTED, response.getSW());
         // test hello world from card
-        response = jcsChannel.transmit(new CommandAPDU(0x01, 0x01, 0x00, 0x00));
+        response = jcsChannel.transmit(new CommandAPDU(0x00, 0x01, 0x00, 0x00));
         assertEquals(0x9000, response.getSW());
         assertEquals("Hello world !", new String(response.getData()));
         // test echo
-        response = jcsChannel.transmit(new CommandAPDU(0x01, 0x01, 0x01, 0x00, ("Hello javacard world !").getBytes()));
+        response = jcsChannel.transmit(new CommandAPDU(0x00, 0x01, 0x01, 0x00, ("Hello javacard world !").getBytes()));
         assertEquals(0x9000, response.getSW());
         assertEquals("Hello javacard world !", new String(response.getData()));
         // test echo v2
-        response = jcsChannel.transmit(new CommandAPDU(0x01, 0x03, 0x00, 0x00, ("Hello javacard world !").getBytes()));
+        response = jcsChannel.transmit(new CommandAPDU(0x00, 0x03, 0x00, 0x00, ("Hello javacard world !").getBytes()));
         assertEquals(0x9000, response.getSW());
         assertEquals("Hello javacard world !", new String(response.getData()));
         // test echo install params
-        response = jcsChannel.transmit(new CommandAPDU(0x01, 0x04, 0x00, 0x00));
+        response = jcsChannel.transmit(new CommandAPDU(0x00, 0x04, 0x00, 0x00));
         assertEquals(0x9000, response.getSW());
         assertEquals(0xF, response.getData()[0]);
         assertEquals(0xF, response.getData()[1]);
         // test continued data
-        response = jcsChannel.transmit(new CommandAPDU(0x01, 0x06, 0x00, 0x00));
+        response = jcsChannel.transmit(new CommandAPDU(0x00, 0x06, 0x00, 0x00));
         assertEquals(0x6107, response.getSW());
         assertEquals("Hello ", new String(response.getData()));
         // test https://github.com/licel/jcardsim/issues/13
@@ -131,11 +131,11 @@ public class JCardSimProviderTest extends TestCase {
         response = jcsChannel.transmit(new CommandAPDU(listObjectsCmd));
         assertEquals(0x9C12, response.getSW());
         // application specific sw + data
-        response = jcsChannel.transmit(new CommandAPDU(0x01, 0x07, 0x00, 0x00));
+        response = jcsChannel.transmit(new CommandAPDU(0x00, 0x07, 0x00, 0x00));
         assertEquals(0x9B00, response.getSW());
         assertEquals("Hello world !", new String(response.getData()));
         // sending maximum data
-        response = jcsChannel.transmit(new CommandAPDU(0x01, 0x08, 0x00, 0x00));
+        response = jcsChannel.transmit(new CommandAPDU(0x00, 0x08, 0x00, 0x00));
         assertEquals(0x9000, response.getSW());
     }
 }

--- a/src/test/java/com/licel/jcardsim/utils/APDUScriptToolTest.java
+++ b/src/test/java/com/licel/jcardsim/utils/APDUScriptToolTest.java
@@ -57,15 +57,15 @@ public class APDUScriptToolTest extends TestCase {
         sb.append("// SELECT APPLET CMD\n");
         sb.append("0x00 0xa4 0x04 0x00 0x09 0x01 0x02 0x03 0x04 0x05 0x06 0x07 0x8 0x09 0x7f;\n");
         sb.append("// TEST NOP\n");
-        sb.append("0x01 0x02 0x00 0x00 0x00 0x2; \n");
+        sb.append("0x00 0x02 0x00 0x00 0x00 0x2; \n");
         sb.append("// TEST SW_INS_NOT_SUPPORTED\n");
-        sb.append("0x01 0x05 0x00 0x00 0x00 0x2 ;\n");
+        sb.append("0x00 0x05 0x00 0x00 0x00 0x2 ;\n");
         sb.append("// test hello world from card\n");
-        sb.append("0x01 0x01 0x00 0x00 0x00 0x0d;\n");
+        sb.append("0x00 0x01 0x00 0x00 0x00 0x0d;\n");
         sb.append("// test echo\n");
-        sb.append("0x01 0x01 0x01 0x00 0x0d 0x48 0x65 0x6c 0x6c 0x6f 0x20 0x77 0x6f 0x72 0x6c 0x64 0x20 0x21 0x0d;\n");
+        sb.append("0x00 0x01 0x01 0x00 0x0d 0x48 0x65 0x6c 0x6c 0x6f 0x20 0x77 0x6f 0x72 0x6c 0x64 0x20 0x21 0x0d;\n");
         sb.append("// test echo2\n");
-        sb.append("0x01 0x03 0x01 0x02 0x05 0x01 0x02 0x03 0x04 0x05 0x7F;");
+        sb.append("0x00 0x03 0x01 0x02 0x05 0x01 0x02 0x03 0x04 0x05 0x7F;");
         sb.append("powerdown;\n");
         InputStream commandsStream = new ByteArrayInputStream(sb.toString().replaceAll("\n", System.getProperty("line.separator")).getBytes());     
         boolean isException = true;
@@ -85,11 +85,11 @@ public class APDUScriptToolTest extends TestCase {
         String expectedOutput =
         "CLA: 80, INS: b8, P1: 00, P2: 00, Lc: 10, 09, 01, 02, 03, 04, 05, 06, 07, 08, 09, 05, 00, 00, 02, 0f, 0f, Le: 09, 01, 02, 03, 04, 05, 06, 07, 08, 09, SW1: 90, SW2: 00\n" +
         "CLA: 00, INS: a4, P1: 04, P2: 00, Lc: 09, 01, 02, 03, 04, 05, 06, 07, 08, 09, Le: 00, SW1: 90, SW2: 00\n" +
-        "CLA: 01, INS: 02, P1: 00, P2: 00, Lc: 00, Le: 00, SW1: 90, SW2: 00\n" +
-        "CLA: 01, INS: 05, P1: 00, P2: 00, Lc: 00, Le: 00, SW1: 6d, SW2: 00\n" +
-        "CLA: 01, INS: 01, P1: 00, P2: 00, Lc: 00, Le: 0d, 48, 65, 6c, 6c, 6f, 20, 77, 6f, 72, 6c, 64, 20, 21, SW1: 90, SW2: 00\n" +
-        "CLA: 01, INS: 01, P1: 01, P2: 00, Lc: 0d, 48, 65, 6c, 6c, 6f, 20, 77, 6f, 72, 6c, 64, 20, 21, Le: 0d, 48, 65, 6c, 6c, 6f, 20, 77, 6f, 72, 6c, 64, 20, 21, SW1: 90, SW2: 00\n" +
-        "CLA: 01, INS: 03, P1: 01, P2: 02, Lc: 05, 01, 02, 03, 04, 05, Le: 05, 01, 02, 03, 04, 05, SW1: 90, SW2: 00\n";
+        "CLA: 00, INS: 02, P1: 00, P2: 00, Lc: 00, Le: 00, SW1: 90, SW2: 00\n" +
+        "CLA: 00, INS: 05, P1: 00, P2: 00, Lc: 00, Le: 00, SW1: 6d, SW2: 00\n" +
+        "CLA: 00, INS: 01, P1: 00, P2: 00, Lc: 00, Le: 0d, 48, 65, 6c, 6c, 6f, 20, 77, 6f, 72, 6c, 64, 20, 21, SW1: 90, SW2: 00\n" +
+        "CLA: 00, INS: 01, P1: 01, P2: 00, Lc: 0d, 48, 65, 6c, 6c, 6f, 20, 77, 6f, 72, 6c, 64, 20, 21, Le: 0d, 48, 65, 6c, 6c, 6f, 20, 77, 6f, 72, 6c, 64, 20, 21, SW1: 90, SW2: 00\n" +
+        "CLA: 00, INS: 03, P1: 01, P2: 02, Lc: 05, 01, 02, 03, 04, 05, Le: 05, 01, 02, 03, 04, 05, SW1: 90, SW2: 00\n";
 
         String output = baos.toString("UTF-8");
         System.out.print(output);


### PR DESCRIPTION
- Simplify language in documentation
- Update URL of "Code Conventions for the Java Programming Language"
- Use CLA=0x00 instead of 0x01
- javadoc: Remove empty "p" tags
- javadoc: Add "." to first sentence
- javadoc: Fix errors detected by Java 8's javadoc
