### PR TITLE
Add new TerminalFactory API: CardTerminalSimulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,26 @@ Key Features:
 * Simplifies unit testing (5 lines of code)
 
 ```java
-//1. create simulator
-JavaxSmartCardInterface simulator = new JavaxSmartCardInterface();
-//2. install applet
+// 1. create simulator
+CardSimulator simulator = new CardSimulator();
+
+// 2. install applet
+AID appletAID = AIDUtil.create("F000000001");
 simulator.installApplet(appletAID, HelloWorldApplet.class);
-//3. select applet
+
+// 3. select applet
 simulator.selectApplet(appletAID);
-//4. send apdu
-ResponseAPDU response = simulator.transmitCommand(new CommandAPDU(0x00, 0x01, 0x00, 0x00));
-//5. check response
+
+// 4. send APDU
+CommandAPDU commandAPDU = new CommandAPDU(0x00, 0x01, 0x00, 0x00);
+ResponseAPDU response = simulator.transmitCommand(commandAPDU);
+
+// 5. check response
 assertEquals(0x9000, response.getSW());
 ```
 
 * Emulation of Java Card Terminal, ability to use `javax.smartcardio`
-* APDU scripting (scripts are compatible with apdutool from Java Card Development Kit)
+* APDU scripting (scripts are compatible with `apdutool` from Java Card Development Kit)
 * Simplifies verification tests creation (Common Criteria)
 
 *JavaDoc*: https://jcardsim.googlecode.com/svn/trunk/javadoc/index.html

--- a/src/main/java/com/licel/jcardsim/base/Simulator.java
+++ b/src/main/java/com/licel/jcardsim/base/Simulator.java
@@ -39,8 +39,8 @@ public class Simulator implements JavaCardInterface {
     static final String DEFAULT_ATR = "3BFA1800008131FE454A434F5033315632333298";
     // ATR system property name
     static final String ATR_SYSTEM_PROPERTY = "com.licel.jcardsim.card.ATR";
-    // card ATR 
-    byte[] atr = null;
+    // card ATR
+    private byte[] atr = null;
     static final String PROPERTY_PREFIX = "com.licel.jcardsim.card.applet.";
     static final String OLD_PROPERTY_PREFIX = "com.licel.jcardsim.smartcardio.applet.";
     // Applet AID system property template

--- a/src/main/java/com/licel/jcardsim/base/SimulatorRuntime.java
+++ b/src/main/java/com/licel/jcardsim/base/SimulatorRuntime.java
@@ -196,6 +196,7 @@ public class SimulatorRuntime {
      * @param aid Applet AID to delete
      */
     protected void deleteApplet(AID aid) {
+        activateSimulatorRuntimeInstance();
         ApplicationInstance applicationInstance = lookupApplet(aid);
         if (applicationInstance == null) {
             throw new SystemException(SystemException.ILLEGAL_AID);
@@ -348,6 +349,7 @@ public class SimulatorRuntime {
     }
 
     protected void deselect(ApplicationInstance applicationInstance) {
+        activateSimulatorRuntimeInstance();
         if (applicationInstance != null) {
             try {
                 Applet applet = applicationInstance.getApplet();
@@ -589,6 +591,7 @@ public class SimulatorRuntime {
 
     public void installApplet(AID loadFileAID, AID moduleAID, final AID appletAID,
                               byte[] bArray, short bOffset, byte bLength) {
+        activateSimulatorRuntimeInstance();
         LoadFile loadFile = loadFiles.get(loadFileAID);
         if (loadFile == null) {
             throw new IllegalArgumentException("LoadFile AID not found " + AIDUtil.toString(loadFileAID));

--- a/src/main/java/com/licel/jcardsim/base/package-info.java
+++ b/src/main/java/com/licel/jcardsim/base/package-info.java
@@ -1,4 +1,4 @@
 /**
- * jCardSim simulator
+ * jCardSim simulator base classes.
  */
 package com.licel.jcardsim.base;

--- a/src/main/java/com/licel/jcardsim/crypto/package-info.java
+++ b/src/main/java/com/licel/jcardsim/crypto/package-info.java
@@ -1,4 +1,4 @@
 /**
- * jCardSim cryptography support classes
+ * jCardSim cryptography support classes.
  */
 package com.licel.jcardsim.crypto;

--- a/src/main/java/com/licel/jcardsim/io/JavaxSmartCardInterface.java
+++ b/src/main/java/com/licel/jcardsim/io/JavaxSmartCardInterface.java
@@ -23,6 +23,8 @@ import javax.smartcardio.ResponseAPDU;
 
 /**
  * Simulator with javacardx.smartcardio Command/Response support.
+ *
+ * NOTE: New code should use {@link com.licel.jcardsim.smartcardio.CardSimulator} instead.
  */
 public class JavaxSmartCardInterface extends Simulator {
     /**

--- a/src/main/java/com/licel/jcardsim/io/package-info.java
+++ b/src/main/java/com/licel/jcardsim/io/package-info.java
@@ -1,4 +1,4 @@
 /**
- * jCardSim I/O support classes
+ * jCardSim I/O support classes.
  */
 package com.licel.jcardsim.io;

--- a/src/main/java/com/licel/jcardsim/remote/JavaCardRemoteServer.java
+++ b/src/main/java/com/licel/jcardsim/remote/JavaCardRemoteServer.java
@@ -16,6 +16,8 @@
 package com.licel.jcardsim.remote;
 
 import com.licel.jcardsim.base.Simulator;
+import com.licel.jcardsim.base.SimulatorRuntime;
+
 import java.io.FileInputStream;
 import java.rmi.RemoteException;
 import java.rmi.registry.LocateRegistry;
@@ -30,13 +32,13 @@ import java.util.Properties;
 public class JavaCardRemoteServer extends java.rmi.server.UnicastRemoteObject
         implements JavaCardRemoteInterface {
     
-    Simulator sim;
+    protected final Simulator sim;
 
     public JavaCardRemoteServer(String host, int port) throws RemoteException {
+        sim = new Simulator(new SimulatorRuntime());
         System.setProperty("java.rmi.server.hostname", host);
         Registry registry = LocateRegistry.createRegistry(port);
         registry.rebind(RMI_SERVER_ID, this);
-        sim = new Simulator();
     }
 
     static public void main(String args[]) throws Exception {
@@ -75,7 +77,8 @@ public class JavaCardRemoteServer extends java.rmi.server.UnicastRemoteObject
             System.err.println("Invalid configuration: missing 'com.licel.jcardsim.terminal.port' property");
             System.exit(-1);
         }
-        JavaCardRemoteServer server = new JavaCardRemoteServer(serverHost, Integer.parseInt(serverPort));
+
+        new JavaCardRemoteServer(serverHost, Integer.parseInt(serverPort));
     }
 
     /**

--- a/src/main/java/com/licel/jcardsim/remote/package-info.java
+++ b/src/main/java/com/licel/jcardsim/remote/package-info.java
@@ -1,4 +1,4 @@
 /**
- * jCardSim remoting support classes
+ * jCardSim remoting support classes.
  */
 package com.licel.jcardsim.remote;

--- a/src/main/java/com/licel/jcardsim/samples/package-info.java
+++ b/src/main/java/com/licel/jcardsim/samples/package-info.java
@@ -1,4 +1,4 @@
 /**
- * Example applets
+ * Example applets.
  */
 package com.licel.jcardsim.samples;

--- a/src/main/java/com/licel/jcardsim/smartcardio/CardSimulator.java
+++ b/src/main/java/com/licel/jcardsim/smartcardio/CardSimulator.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2015 Robert Bachmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.licel.jcardsim.smartcardio;
+
+import com.licel.jcardsim.base.CardManager;
+import com.licel.jcardsim.base.SimulatorRuntime;
+import com.licel.jcardsim.io.JavaxSmartCardInterface;
+
+import javax.smartcardio.*;
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Simulates a JavaCard.
+ *
+ * @see com.licel.jcardsim.smartcardio.CardTerminalSimulator
+ */
+public class CardSimulator extends JavaxSmartCardInterface {
+    private final CardImpl card = new CardImpl();
+    private final AtomicReference<CardTerminal> owningCardTerminalReference
+            = new AtomicReference<CardTerminal>();
+    private final AtomicReference<Thread> threadReference = new AtomicReference<Thread>();
+
+    /**
+     * Create a Simulator object using a new SimulatorRuntime.
+     * <ul>
+     * <li>SimulatorRuntime#resetRuntime is called</li>
+     * </ul>
+     */
+    public CardSimulator() {
+        this(new SimulatorRuntime());
+    }
+
+    /**
+     * Create a Simulator object using a provided Runtime.
+     * <ul>
+     * <li>SimulatorRuntime#resetRuntime is called</li>
+     * </ul>
+     *
+     * @param runtime SimulatorRuntime instance to use
+     * @throws java.lang.NullPointerException if <code>runtime</code> is null
+     */
+    public CardSimulator(SimulatorRuntime runtime) {
+        super(runtime);
+    }
+
+    /**
+     * Wrapper for {@link #transmitCommand(byte[])}
+     *
+     * @param commandApdu CommandAPDU
+     * @return ResponseAPDU
+     */
+    @Override
+    public ResponseAPDU transmitCommand(CommandAPDU commandApdu) {
+        return new ResponseAPDU(transmitCommand(commandApdu.getBytes()));
+    }
+
+    /**
+     * <p>Assigns this simulated card to a CardTerminal.</p>
+     * <p>If the card is already assigned to another CardTerminal, it will be ejected
+     * and inserted into the CardTerminal <code>terminal</code>.</p>
+     *
+     * @param terminal card terminal or <code>null</code>
+     */
+    public synchronized void assignToTerminal(CardTerminal terminal) {
+        final CardTerminal oldCardTerminal = owningCardTerminalReference.getAndSet(terminal);
+
+        if (terminal == oldCardTerminal) {
+            return;
+        }
+
+        if (oldCardTerminal != null) {
+            // eject card from old Terminal
+            ((CardTerminalSimulator.CardTerminalImpl) oldCardTerminal).assignSimulator(null);
+        }
+
+        if (terminal != null) {
+            // reset card
+            card.disconnect();
+            // assign to new terminal
+            ((CardTerminalSimulator.CardTerminalImpl) terminal).assignSimulator(this);
+        }
+    }
+
+    /**
+     * @return the assigned CardTerminal or null if none is assigned
+     */
+    public CardTerminal getAssignedCardTerminal() {
+        return owningCardTerminalReference.get();
+    }
+
+    final Card internalConnect(String protocol) {
+        card.connect(protocol);
+        return card;
+    }
+
+    final void internalEject(CardTerminal oldTerminal) {
+        if (owningCardTerminalReference.compareAndSet(oldTerminal, null)) {
+            card.eject();
+        }
+    }
+
+    private enum CardState {
+        Connected, Disconnected, Ejected
+    }
+
+    private static final class CardChannelImpl extends CardChannel {
+        private final CardImpl card;
+        private final int channelNr;
+
+        public CardChannelImpl(CardImpl card, int channelNr) {
+            this.card = card;
+            this.channelNr = channelNr;
+        }
+
+        @Override
+        public Card getCard() {
+            return card;
+        }
+
+        @Override
+        public int getChannelNumber() {
+            card.ensureConnected();
+            return channelNr;
+        }
+
+        @Override
+        public ResponseAPDU transmit(CommandAPDU commandAPDU) throws CardException {
+            return new ResponseAPDU(card.transmitCommand(commandAPDU.getBytes()));
+        }
+
+        @Override
+        public int transmit(ByteBuffer byteBuffer, ByteBuffer byteBuffer2) throws CardException {
+            byte[] result = card.transmitCommand(new CommandAPDU(byteBuffer).getBytes());
+            byteBuffer2.put(result);
+            return result.length;
+        }
+
+        @Override
+        public void close() throws CardException {
+            throw new CardException("Can not close basic channel");
+        }
+    }
+
+    private final class CardImpl extends Card {
+        private final CardChannel basicChannel;
+        private volatile String protocol = "T=0";
+        private volatile byte protocolByte = 0;
+        private volatile CardState state = CardState.Connected;
+
+        CardImpl() {
+            this.basicChannel = new CardChannelImpl(this, 0);
+        }
+
+        void ensureConnected() {
+            CardState cardState = state;
+            if (cardState == CardState.Disconnected) {
+                throw new IllegalStateException("Card was disconnected");
+            } else if (cardState == CardState.Ejected) {
+                throw new IllegalStateException("Card was removed");
+            }
+        }
+
+        @Override
+        public ATR getATR() {
+            return new ATR(CardSimulator.this.getATR());
+        }
+
+        @Override
+        public String getProtocol() {
+            return protocol;
+        }
+
+        @Override
+        public CardChannel getBasicChannel() {
+            return basicChannel;
+        }
+
+        @Override
+        public CardChannel openLogicalChannel() throws CardException {
+            throw new CardException("Logical channel not supported");
+        }
+
+        @Override
+        public void beginExclusive() throws CardException {
+            synchronized (runtime) {
+                if (!threadReference.compareAndSet(null, Thread.currentThread())) {
+                    throw new CardException("Card is held exclusively by Thread " + threadReference.get());
+                }
+            }
+        }
+
+        @Override
+        public void endExclusive() throws CardException {
+            synchronized (runtime) {
+                if (!threadReference.compareAndSet(Thread.currentThread(), null)) {
+                    throw new CardException("Card is held exclusively by Thread " + threadReference.get());
+                }
+            }
+        }
+
+        @Override
+        public byte[] transmitControlCommand(int i, byte[] bytes) throws CardException {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public void disconnect(boolean reset) throws CardException {
+            synchronized (runtime) {
+                if (reset) {
+                    CardSimulator.this.reset();
+                }
+                state = CardState.Disconnected;
+            }
+        }
+
+        void connect(String protocol) {
+            synchronized (runtime) {
+                this.protocolByte = CardSimulator.this.getProtocolByte(protocol);
+                this.protocol = protocol;
+                this.state = CardState.Connected;
+            }
+        }
+
+        void eject() {
+            synchronized (runtime) {
+                CardSimulator.this.reset();
+                state = CardState.Ejected;
+            }
+        }
+
+        void disconnect() {
+            synchronized (runtime) {
+                CardSimulator.this.reset();
+                state = CardState.Disconnected;
+            }
+        }
+
+        byte[] transmitCommand(byte[] capdu) throws CardException {
+            synchronized (runtime) {
+                ensureConnected();
+                Thread thread = threadReference.get();
+                if (thread != null && thread != Thread.currentThread()) {
+                    throw new CardException("Card is held exclusively by Thread " + thread.getName());
+                }
+
+                byte currentProtocol = getProtocolByte(CardSimulator.this.getProtocol());
+                try {
+                    runtime.changeProtocol(protocolByte);
+                    return CardManager.dispatchApdu(CardSimulator.this, capdu);
+                } finally {
+                    runtime.changeProtocol(currentProtocol);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/licel/jcardsim/smartcardio/CardTerminalSimulator.java
+++ b/src/main/java/com/licel/jcardsim/smartcardio/CardTerminalSimulator.java
@@ -1,0 +1,356 @@
+/*
+ * Copyright 2015 Robert Bachmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.licel.jcardsim.smartcardio;
+
+import com.licel.jcardsim.utils.AutoResetEvent;
+
+import javax.smartcardio.*;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.security.Provider;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * <p>A simulated {@link javax.smartcardio.TerminalFactory}.</p>
+ * <p>Example: Obtaining a Card</p>
+ * <pre>
+ * // create card simulator
+ * CardSimulator cardSimulator = new CardSimulator();
+ *
+ * // connect to a card
+ * CardTerminal terminal =
+ *   CardTerminalSimulator.terminal(cardSimulator);
+ * Card card = terminal.connect("*");
+ * </pre>
+ * <p>Example: Inserting/ejecting a Card</p>
+ * <pre>
+ * // create card simulator
+ * CardSimulator cardSimulator = new CardSimulator();
+ *
+ * // create CardTerminal
+ * CardTerminals terminals = CardTerminalSimulator.terminals("my terminal")
+ * CardTerminal terminal = terminals.getTerminal("my terminal");
+ *
+ * // insert Card
+ * cardSimulator.assignToTerminal(terminal);
+ *
+ * // eject Card
+ * cardSimulator.assignToTerminal(null);
+ * </pre>
+ *
+ * @see com.licel.jcardsim.smartcardio.CardSimulator
+ */
+public final class CardTerminalSimulator {
+    private CardTerminalSimulator() {
+    }
+
+    /**
+     * Create a single CardTerminal.
+     *
+     * @param cardSimulator card to insert
+     * @param name          the terminal name
+     * @return a new <code>CardTerminal</code> instance
+     * @throws java.lang.NullPointerException if name or cardSimulator is null
+     */
+    public static CardTerminal terminal(CardSimulator cardSimulator, String name) {
+        if (name == null) {
+            throw new NullPointerException("name");
+        }
+        if (cardSimulator == null) {
+            throw new NullPointerException("cardSimulator");
+        }
+        CardTerminal cardTerminal = terminals(name).getTerminal(name);
+        cardSimulator.assignToTerminal(cardTerminal);
+        return cardTerminal;
+    }
+
+    /**
+     * Create a CardTerminal with name "jCardSim.Terminal".
+     *
+     * @param cardSimulator card to insert
+     * @return a new <code>CardTerminal</code> instance
+     * @throws java.lang.NullPointerException if name or cardSimulator is null
+     */
+    public static CardTerminal terminal(CardSimulator cardSimulator) {
+        return terminal(cardSimulator, "jCardSim.Terminal");
+    }
+
+    /**
+     * <p>Create CardTerminals.</p>
+     * <p>Example:</p>
+     * <pre>
+     *  CardTerminals terminals = CardTerminalSimulator.terminals("1","2");
+     *  CardTerminal terminal = terminals.getTerminal("1");
+     *
+     *  // assign simulator
+     *  CardSimulator cardSimulator = new CardSimulator();
+     *  cardSimulator.assignToTerminal(terminal);
+     * </pre>
+     *
+     * @param names the terminal names
+     * @return a new <code>CardTerminals</code> instance
+     * @throws java.lang.NullPointerException     if names is null
+     * @throws java.lang.IllegalArgumentException if any name is null or duplicated
+     * @see javax.smartcardio.CardTerminals
+     */
+    public static CardTerminals terminals(String... names) {
+        if (names == null) {
+            throw new NullPointerException("names");
+        }
+        Set<String> set = new HashSet<String>(names.length);
+        for (String name : names) {
+            if (set.contains(name)) {
+                throw new IllegalArgumentException("Duplicate name '" + name + "'");
+            }
+            set.add(name);
+        }
+        return new CardTerminalsImpl(names);
+    }
+
+    /**
+     * <p>Security provider.</p>
+     * <p>Register the SecurityProvider with:</p>
+     * <pre>
+     * if (Security.getProvider("CardTerminalSimulator") == null) {
+     *     Security.addProvider(new CardTerminalSimulator.SecurityProvider());
+     * }
+     * </pre>
+     */
+    public static final class SecurityProvider extends Provider {
+        public SecurityProvider() {
+            super("CardTerminalSimulator", 1.0d, "jCardSim Virtual Terminal Provider");
+            AccessController.doPrivileged(new PrivilegedAction() {
+                public Object run() {
+                    put("TerminalFactory." + "CardTerminalSimulator", Factory.class.getCanonicalName()
+                            .replace(".Factory", "$Factory"));
+                    return null;
+                }
+            });
+        }
+    }
+
+    /**
+     * {@link javax.smartcardio.TerminalFactorySpi} implementation.
+     * Applications do not access this class directly, instead see {@link javax.smartcardio.TerminalFactory}.
+     */
+    @SuppressWarnings("unused")
+    public static final class Factory extends TerminalFactorySpi {
+        private final CardTerminals cardTerminals;
+
+        public Factory(Object params) {
+            String[] names;
+            if (params == null) {
+                names = new String[]{"jCardSim.Terminal"};
+            } else if (params instanceof String) {
+                names = new String[]{(String) params};
+            } else if (params instanceof String[]) {
+                names = (String[]) params;
+            } else {
+                throw new IllegalArgumentException("Illegal parameter: " + params);
+            }
+            cardTerminals = terminals(names);
+        }
+
+        @Override
+        protected CardTerminals engineTerminals() {
+            return cardTerminals;
+        }
+    }
+
+    static boolean waitForLatch(AutoResetEvent autoResetEvent, long timeoutMilliseconds) throws InterruptedException {
+        if (timeoutMilliseconds < 0) {
+            throw new IllegalArgumentException("timeout is negative");
+        }
+        if (timeoutMilliseconds == 0) { // wait forever
+            boolean success;
+            do {
+                success = autoResetEvent.await(1, TimeUnit.MINUTES);
+            } while (!success);
+            return true;
+        }
+        return autoResetEvent.await(timeoutMilliseconds, TimeUnit.MILLISECONDS);
+    }
+
+    static final class CardTerminalsImpl extends CardTerminals {
+        private final AtomicBoolean waitCalled = new AtomicBoolean(false);
+        private final AutoResetEvent terminalsChangeAutoResetEvent = new AutoResetEvent();
+        private final ArrayList<CardTerminalImpl> simulatedTerminals;
+        private final HashMap<CardTerminal, State> terminalStateMap;
+
+        CardTerminalsImpl(String[] names) {
+            simulatedTerminals = new ArrayList<CardTerminalImpl>(names.length);
+            terminalStateMap = new HashMap<CardTerminal, State>(names.length);
+            for (String name : names) {
+                simulatedTerminals.add(new CardTerminalImpl(name, terminalStateMap, terminalsChangeAutoResetEvent));
+            }
+        }
+
+        @Override
+        public synchronized List<CardTerminal> list(State state) throws CardException {
+            if (state == null) {
+                throw new NullPointerException("state");
+            }
+            synchronized (terminalStateMap) {
+                final ArrayList<CardTerminal> result = new ArrayList<CardTerminal>(simulatedTerminals.size());
+
+                for (CardTerminal terminal : simulatedTerminals) {
+                    State terminalState = terminalStateMap.get(terminal);
+                    switch (state) {
+                        case ALL:
+                            result.add(terminal);
+                            break;
+                        case CARD_ABSENT:
+                            if (!terminal.isCardPresent() && terminalState != State.CARD_REMOVAL) {
+                                result.add(terminal);
+                            }
+                            break;
+                        case CARD_PRESENT:
+                            if (terminal.isCardPresent() && terminalState != State.CARD_INSERTION) {
+                                result.add(terminal);
+                            }
+                            break;
+                        case CARD_INSERTION:
+                            if (waitCalled.get()) {
+                                if (terminalState == State.CARD_INSERTION) {
+                                    terminalStateMap.put(terminal, State.CARD_PRESENT);
+                                    result.add(terminal);
+                                }
+                            } else if (terminal.isCardPresent()) {
+                                result.add(terminal);
+                            }
+                            break;
+                        case CARD_REMOVAL:
+                            if (waitCalled.get()) {
+                                if (terminalState == State.CARD_REMOVAL) {
+                                    terminalStateMap.put(terminal, State.CARD_ABSENT);
+                                    result.add(terminal);
+                                }
+                            } else if (!terminal.isCardPresent()) {
+                                result.add(terminal);
+                            }
+                            break;
+                    }
+                }
+                return Collections.unmodifiableList(result);
+            }
+        }
+
+        @Override
+        public boolean waitForChange(long timeoutMilliseconds) throws CardException {
+            try {
+                return waitForLatch(terminalsChangeAutoResetEvent, timeoutMilliseconds);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            } finally {
+                waitCalled.set(true);
+            }
+        }
+    }
+
+    static final class CardTerminalImpl extends CardTerminal {
+        private final String name;
+        private final Map<CardTerminal, CardTerminals.State> terminalStateMap;
+        private final AutoResetEvent terminalsChangeAutoResetEvent;
+        private final AutoResetEvent cardPresent = new AutoResetEvent();
+        private final AutoResetEvent cardAbsent = new AutoResetEvent();
+        private final AtomicReference<CardSimulator> cardSimulatorReference = new AtomicReference<CardSimulator>();
+
+        CardTerminalImpl(String name, Map<CardTerminal, CardTerminals.State> terminalStateMap, AutoResetEvent terminalsChangeAutoResetEvent) {
+            this.name = name;
+            this.terminalStateMap = terminalStateMap;
+            this.terminalsChangeAutoResetEvent = terminalsChangeAutoResetEvent;
+            cardAbsent.signal();
+            terminalStateMap.put(this, CardTerminals.State.CARD_ABSENT);
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public Card connect(String protocol) throws CardException {
+            CardSimulator cardSimulator = cardSimulatorReference.get();
+            if (cardSimulator == null) {
+                throw new CardNotPresentException("No card inserted. You need to call CardTerminalSimulator#assignToTerminal");
+            }
+            return cardSimulator.internalConnect(protocol);
+        }
+
+        @Override
+        public boolean isCardPresent() throws CardException {
+            return cardSimulatorReference.get() != null;
+        }
+
+        @Override
+        public boolean waitForCardPresent(long timeoutMilliseconds) throws CardException {
+            try {
+                return waitForLatch(cardPresent, timeoutMilliseconds);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+        }
+
+        @Override
+        public boolean waitForCardAbsent(long timeoutMilliseconds) throws CardException {
+            try {
+                return waitForLatch(cardAbsent, timeoutMilliseconds);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+        }
+
+        void assignSimulator(CardSimulator cardSimulator) {
+            synchronized (terminalStateMap) {
+                CardSimulator oldCardSimulator = cardSimulatorReference.getAndSet(cardSimulator);
+                boolean change = false;
+                boolean present = false;
+
+                if (oldCardSimulator != null) {
+                    oldCardSimulator.internalEject(this);
+                    change = true;
+                }
+                if (cardSimulator != null) {
+                    present = true;
+                    change = true;
+                }
+                if (change) {
+                    if (present) {
+                        terminalStateMap.put(this, CardTerminals.State.CARD_INSERTION);
+                        cardPresent.signal();
+                        cardAbsent.reset();
+                    } else {
+                        terminalStateMap.put(this, CardTerminals.State.CARD_REMOVAL);
+                        cardPresent.reset();
+                        cardAbsent.signal();
+                    }
+                    terminalsChangeAutoResetEvent.signal();
+                }
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "jCardSim Terminal: " + name;
+        }
+    }
+}

--- a/src/main/java/com/licel/jcardsim/smartcardio/package-info.java
+++ b/src/main/java/com/licel/jcardsim/smartcardio/package-info.java
@@ -1,4 +1,4 @@
 /**
- * jCardSim <code>javax.smartcardio</code> provider
+ * jCardSim card simulation and <code>javax.smartcardio</code> support.
  */
 package com.licel.jcardsim.smartcardio;

--- a/src/main/java/com/licel/jcardsim/utils/AutoResetEvent.java
+++ b/src/main/java/com/licel/jcardsim/utils/AutoResetEvent.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2015 Robert Bachmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.licel.jcardsim.utils;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.AbstractQueuedSynchronizer;
+
+/**
+ * Java version of .Net's <code>AutoResetEvent</code>.
+ * <p>See <a href=
+ * "http://msdn.microsoft.com/en-us/library/system.threading.autoresetevent(v=vs.110).aspx">MSDN</a>.</p>
+ */
+public final class AutoResetEvent {
+    private final static int SIGNALED = 1;
+    private final static int NOT_SIGNALED = 0;
+    private final Sync sync = new Sync();
+
+    /**
+     * Wake up one thread that is waiting.
+     */
+    public void signal() {
+        sync.releaseShared(SIGNALED);
+    }
+
+    /**
+     * Reset.
+     */
+    public void reset() {
+        sync.releaseShared(NOT_SIGNALED);
+    }
+
+    /**
+     * Wait until thread is signaled or interrupted.
+     * @param time time to wait
+     * @param unit time unit of <code>time</code>
+     * @return true if signaled
+     * @throws InterruptedException if the thread is interrupted
+     */
+    public boolean await(long time, TimeUnit unit) throws InterruptedException {
+        return sync.tryAcquireSharedNanos(1, unit.toNanos(time));
+    }
+
+    private static class Sync extends AbstractQueuedSynchronizer {
+        Sync() {
+            setState(NOT_SIGNALED);
+        }
+
+        protected int tryAcquireShared(int ignore) {
+            if (compareAndSetState(SIGNALED, NOT_SIGNALED)) {
+                return 1;
+            }
+            return -1;
+        }
+
+        protected boolean tryReleaseShared(int state) {
+            setState(state);
+            return true;
+        }
+    }
+}

--- a/src/main/java/com/licel/jcardsim/utils/ByteUtil.java
+++ b/src/main/java/com/licel/jcardsim/utils/ByteUtil.java
@@ -73,7 +73,7 @@ public final class ByteUtil {
 
     /**
      * Extract status word from APDU
-     * @param apduBuffer apdu bytes
+     * @param apduBuffer APDU bytes
      * @return status word
      * @throws java.lang.NullPointerException if <code>apduBuffer</code> is null
      * @throws java.lang.IllegalArgumentException if <code>apduBuffer.length</code>  is &lt; 2
@@ -86,6 +86,33 @@ public final class ByteUtil {
             throw new IllegalArgumentException("bytes.length must be at least 2");
         }
         return getShort(apduBuffer, apduBuffer.length - 2);
+    }
+
+    /**
+     * Check status word from APDU
+     * @param apduBuffer APDU bytes
+     * @param expected expected status word
+     * @throws java.lang.NullPointerException if <code>apduBuffer</code> is null
+     * @throws java.lang.IllegalArgumentException if <code>apduBuffer.length</code>  is &lt; 2
+     * @throws java.lang.AssertionError if <code>expected</code> does not match the status word from <code>apduBuffer</code>
+     */
+    public static void requireSW(byte[] apduBuffer, int expected) {
+        int sw = getSW(apduBuffer) & 0xFFFF;
+        if (sw != expected) {
+            throw new AssertionError(String.format("Expected status word %x but got %x", expected, sw));
+        }
+    }
+
+    /**
+     * Check status word from APDU
+     * @param apduBuffer APDU bytes
+     * @param expected expected status word
+     * @throws java.lang.NullPointerException if <code>apduBuffer</code> is null
+     * @throws java.lang.IllegalArgumentException if <code>apduBuffer.length</code>  is &lt; 2
+     * @throws java.lang.AssertionError if <code>expected</code> does not match the status word from <code>apduBuffer</code>
+     */
+    public static void requireSW(byte[] apduBuffer, short expected) {
+        requireSW(apduBuffer, expected & 0xFFFF);
     }
 
     /**

--- a/src/main/java/com/licel/jcardsim/utils/package-info.java
+++ b/src/main/java/com/licel/jcardsim/utils/package-info.java
@@ -1,4 +1,4 @@
 /**
- * Utility classes
+ * Utility classes.
  */
 package com.licel.jcardsim.utils;

--- a/src/main/java/javacard/framework/package-info.java
+++ b/src/main/java/javacard/framework/package-info.java
@@ -1,4 +1,4 @@
 /**
- * JavaCard API
+ * JavaCard API.
  */
 package javacard.framework;

--- a/src/main/java/javacard/framework/service/package-info.java
+++ b/src/main/java/javacard/framework/service/package-info.java
@@ -1,4 +1,4 @@
 /**
- * JavaCard API
+ * JavaCard API.
  */
 package javacard.framework.service;

--- a/src/main/java/javacard/security/package-info.java
+++ b/src/main/java/javacard/security/package-info.java
@@ -1,4 +1,4 @@
 /**
- * JavaCard API
+ * JavaCard API.
  */
 package javacard.security;

--- a/src/main/java/javacardx/apdu/package-info.java
+++ b/src/main/java/javacardx/apdu/package-info.java
@@ -1,4 +1,4 @@
 /**
- * JavaCard API
+ * JavaCard API.
  */
 package javacardx.apdu;

--- a/src/main/java/javacardx/crypto/package-info.java
+++ b/src/main/java/javacardx/crypto/package-info.java
@@ -1,4 +1,4 @@
 /**
- * JavaCard API
+ * JavaCard API.
  */
 package javacardx.crypto;

--- a/src/test/java/com/licel/jcardsim/DocumentationCodeSamplesTest.java
+++ b/src/test/java/com/licel/jcardsim/DocumentationCodeSamplesTest.java
@@ -1,0 +1,189 @@
+package com.licel.jcardsim;
+
+import com.licel.jcardsim.samples.HelloWorldApplet;
+import com.licel.jcardsim.smartcardio.CardSimulator;
+import com.licel.jcardsim.smartcardio.CardTerminalSimulator;
+import com.licel.jcardsim.utils.AIDUtil;
+import com.licel.jcardsim.utils.ByteUtil;
+import javacard.framework.AID;
+import junit.framework.TestCase;
+
+import javax.smartcardio.*;
+import java.security.NoSuchAlgorithmException;
+import java.security.Security;
+
+/**
+ * Contains all listing from the documentation
+ */
+public class DocumentationCodeSamplesTest extends TestCase {
+    public void testCodeListingReadme() {
+        // 1. Create simulator
+        CardSimulator simulator = new CardSimulator();
+
+        // 2. Install applet
+        AID appletAID = AIDUtil.create("F000000001");
+        simulator.installApplet(appletAID, HelloWorldApplet.class);
+
+        // 3. Select applet
+        simulator.selectApplet(appletAID);
+
+        // 4. Send APDU
+        CommandAPDU commandAPDU = new CommandAPDU(0x00, 0x01, 0x00, 0x00);
+        ResponseAPDU response = simulator.transmitCommand(commandAPDU);
+
+        // 5. Check response status word
+        assertEquals(0x9000, response.getSW());
+    }
+
+    public void testCodeListing1() {
+        // 1. Create simulator
+        CardSimulator simulator = new CardSimulator();
+
+        // 2. Install applet
+        AID appletAID = AIDUtil.create("F000000001");
+        simulator.installApplet(appletAID, HelloWorldApplet.class);
+
+        // 3. Select applet
+        simulator.selectApplet(appletAID);
+
+        // 4. Send APDU
+        CommandAPDU commandAPDU = new CommandAPDU(0x00, 0x01, 0x00, 0x00);
+        ResponseAPDU response = simulator.transmitCommand(commandAPDU);
+
+        // 5. Check response status word
+        assertEquals(0x9000, response.getSW());
+    }
+
+
+    public void testCodeListing2() {
+        CardSimulator simulator = new CardSimulator();
+
+        byte[] appletAIDBytes = new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9};
+        AID appletAID = new AID(appletAIDBytes, (short) 0, (byte) appletAIDBytes.length);
+
+        simulator.installApplet(appletAID, HelloWorldApplet.class);
+        simulator.selectApplet(appletAID);
+
+        // test NOP
+        ResponseAPDU response = simulator.transmitCommand(new CommandAPDU(0x00, 0x02, 0x00, 0x00));
+        assertEquals(0x9000, response.getSW());
+
+        // test hello world from card
+        response = simulator.transmitCommand(new CommandAPDU(0x00, 0x01, 0x00, 0x00));
+        assertEquals(0x9000, response.getSW());
+        assertEquals("Hello world !", new String(response.getData()));
+
+        // test echo
+        CommandAPDU echo = new CommandAPDU(0x00, 0x01, 0x01, 0x00, ("Hello javacard world !").getBytes());
+        response = simulator.transmitCommand(echo);
+        assertEquals(0x9000, response.getSW());
+        assertEquals("Hello javacard world !", new String(response.getData()));
+    }
+
+    public void testCodeListing3() {
+        CardSimulator simulator = new CardSimulator();
+
+        byte[] appletAIDBytes = new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9};
+        AID appletAID = new AID(appletAIDBytes, (short) 0, (byte) appletAIDBytes.length);
+
+        simulator.installApplet(appletAID, HelloWorldApplet.class);
+        simulator.selectApplet(appletAID);
+
+        // test NOP
+        byte[] response = simulator.transmitCommand(new byte[]{0x00, 0x02, 0x00, 0x00});
+        ByteUtil.requireSW(response, 0x9000);
+    }
+
+    public void testCodeListing4() {
+        // AID from byte array
+        AID applet1AID = AIDUtil.create(new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9});
+
+        // AID form String
+        AID applet2AID = AIDUtil.create("010203040506070809");
+
+        assertEquals(applet1AID, applet2AID);
+
+        // String to byte array
+        String hexString = ByteUtil.hexString(new byte[]{0,2,0,0});
+
+        // byte array from String
+        byte[] bytes = ByteUtil.byteArray("00 02 00 00");
+
+        assertEquals("00020000", hexString);
+        assertEquals("00020000", ByteUtil.hexString(bytes));
+    }
+
+    public void testCodeListing5() throws CardException {
+        // 1. Create simulator and install applet
+        CardSimulator simulator = new CardSimulator();
+        AID appletAID = AIDUtil.create("F000000001");
+        simulator.installApplet(appletAID, HelloWorldApplet.class);
+
+        // 2. Create Terminal
+        CardTerminal terminal = CardTerminalSimulator.terminal(simulator);
+
+        // 3. Connect to Card
+        Card card = terminal.connect("T=1");
+        CardChannel channel = card.getBasicChannel();
+
+        // 4. Select applet
+        CommandAPDU selectCommand = new CommandAPDU(AIDUtil.select(appletAID));
+        channel.transmit(selectCommand);
+
+        // 5. Send APDU
+        CommandAPDU commandAPDU = new CommandAPDU(0x00, 0x01, 0x00, 0x00);
+        ResponseAPDU response = simulator.transmitCommand(commandAPDU);
+
+        // 6. Check response status word
+        assertEquals(0x9000, response.getSW());
+    }
+
+    public void testCodeListing6() throws CardException {
+        // Obtain CardTerminal
+        CardTerminals cardTerminals = CardTerminalSimulator.terminals("My terminal 1", "My terminal 2");
+        CardTerminal terminal1 = cardTerminals.getTerminal("My terminal 1");
+        CardTerminal terminal2 = cardTerminals.getTerminal("My terminal 2");
+
+        assertEquals(false, terminal1.isCardPresent());
+        assertEquals(false, terminal2.isCardPresent());
+
+        // Create simulator and install applet
+        CardSimulator simulator = new CardSimulator();
+        AID appletAID = AIDUtil.create("F000000001");
+        simulator.installApplet(appletAID, HelloWorldApplet.class);
+
+        // Insert Card into "My terminal 1"
+        simulator.assignToTerminal(terminal1);
+        assertEquals(true, terminal1.isCardPresent());
+        assertEquals(false, terminal2.isCardPresent());
+    }
+
+    public void testCodeListing7() throws CardException, NoSuchAlgorithmException {
+        // Register provider
+        if (Security.getProvider("CardTerminalSimulator") == null) {
+            Security.addProvider(new CardTerminalSimulator.SecurityProvider());
+        }
+
+        // Get TerminalFactory
+        TerminalFactory factory = TerminalFactory.getInstance("CardTerminalSimulator", null);
+        CardTerminals cardTerminals = factory.terminals();
+
+        // Get CardTerminal
+        CardTerminal terminal = cardTerminals.getTerminal("jCardSim.Terminal");
+        assertNotNull(terminal);
+    }
+
+    public void testCodeListing8() throws CardException, NoSuchAlgorithmException {
+        // Register provider
+        if (Security.getProvider("CardTerminalSimulator") == null) {
+            Security.addProvider(new CardTerminalSimulator.SecurityProvider());
+        }
+
+        // Get TerminalFactory with custom names
+        String[] names = new String[] {"My terminal 1", "My terminal 2"};
+        TerminalFactory factory = TerminalFactory.getInstance("CardTerminalSimulator", names);
+        CardTerminals cardTerminals = factory.terminals();
+        assertNotNull(cardTerminals.getTerminal("My terminal 1"));
+        assertNotNull(cardTerminals.getTerminal("My terminal 2"));
+    }
+}

--- a/src/test/java/com/licel/jcardsim/remote/JavaCardRemoteServerTest.java
+++ b/src/test/java/com/licel/jcardsim/remote/JavaCardRemoteServerTest.java
@@ -1,0 +1,38 @@
+package com.licel.jcardsim.remote;
+
+import com.licel.jcardsim.utils.AIDUtil;
+import javacard.framework.AID;
+import junit.framework.TestCase;
+import org.bouncycastle.util.Arrays;
+
+import java.rmi.NotBoundException;
+import java.rmi.RemoteException;
+
+public class JavaCardRemoteServerTest extends TestCase {
+    private static final String TEST_APPLET_AID = "010203040506070809";
+    private static final String TEST_APPLET_CLASS = "com.licel.jcardsim.samples.HelloWorldApplet";
+
+    public JavaCardRemoteServerTest(String name) {
+        super(name);
+    }
+
+    public void testServer() throws RemoteException, NotBoundException, InterruptedException {
+        System.out.println("testServer ...");
+        System.setProperty("com.licel.jcardsim.card.applet.0.AID", TEST_APPLET_AID);
+        System.setProperty("com.licel.jcardsim.card.applet.0.Class", TEST_APPLET_CLASS);
+
+        String host = "127.0.0.1";
+        int port = 7777;
+        new JavaCardRemoteServer(host, port);
+        JavaCardRemoteClient client = new JavaCardRemoteClient(host, port);
+
+        final AID aid = AIDUtil.create(TEST_APPLET_AID);
+        client.createApplet(aid, new byte[0], (short) 0, (byte) 0);
+
+        assertEquals(true, client.selectApplet(aid));
+        // test NOP
+        byte[] response = client.transmitCommand(new byte[]{0x01, 0x02, 0x00, 0x00});
+        assertEquals(Arrays.areEqual(new byte[]{(byte) 0x90, 0x00}, response), true);
+        System.out.println("testServer ... done");
+    }
+}

--- a/src/test/java/com/licel/jcardsim/smartcardio/CardTerminalSimulatorTest.java
+++ b/src/test/java/com/licel/jcardsim/smartcardio/CardTerminalSimulatorTest.java
@@ -1,0 +1,325 @@
+package com.licel.jcardsim.smartcardio;
+
+import com.licel.jcardsim.utils.AutoResetEvent;
+import javacard.framework.ISO7816;
+import junit.framework.TestCase;
+import org.bouncycastle.util.encoders.Hex;
+
+import javax.smartcardio.*;
+import java.security.NoSuchAlgorithmException;
+import java.security.Security;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class CardTerminalSimulatorTest extends TestCase {
+    private static final ATR ETALON_ATR = new ATR(Hex.decode("3BFA1800008131FE454A434F5033315632333298"));
+    private static final String TEST_APPLET_AID = "010203040506070809";
+
+    public CardTerminalSimulatorTest(String name) {
+        super(name);
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        System.setProperty("com.licel.jcardsim.card.applet.0.AID", TEST_APPLET_AID);
+        System.setProperty("com.licel.jcardsim.card.applet.0.Class", "com.licel.jcardsim.samples.HelloWorldApplet");
+    }
+
+    public void testCreateSingleTerminal() throws CardException, InterruptedException {
+        final AutoResetEvent autoResetEvent = new AutoResetEvent();
+
+        // get instance
+        final CardTerminals terminals = CardTerminalSimulator.terminals("my terminal");
+        final CardTerminal terminal = terminals.getTerminal("my terminal");
+
+        // create and insert card
+        CardSimulator cardSimulator = new CardSimulator();
+        cardSimulator.assignToTerminal(terminal);
+        assertSame(terminal, cardSimulator.getAssignedCardTerminal());
+
+        // connect to card
+        Card card = terminal.connect("T=1");
+        test(card);
+
+        // assign same card
+        new Thread() {
+            @Override
+            public void run() {
+                try {
+                    if (terminals.waitForChange(0)) {
+                        autoResetEvent.signal();
+                    }
+                } catch (CardException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }.start();
+        cardSimulator.assignToTerminal(terminal);
+        assertTrue(autoResetEvent.await(1, TimeUnit.SECONDS));
+        assertSame(terminal, cardSimulator.getAssignedCardTerminal());
+
+        // assign different card
+        CardSimulator cardSimulator2 = new CardSimulator();
+        assertNull(cardSimulator2.getAssignedCardTerminal());
+        cardSimulator2.assignToTerminal(terminal);
+
+        assertSame(terminal, cardSimulator2.getAssignedCardTerminal());
+        assertNull(cardSimulator.getAssignedCardTerminal());
+    }
+
+    public void testCreateTerminals() throws CardException {
+        // get instance
+        CardTerminals terminals = CardTerminalSimulator.terminals("terminal #1", "terminal #2");
+        CardTerminal terminal = terminals.getTerminal("terminal #2");
+
+        // create and insert card
+        CardSimulator cardSimulator = new CardSimulator();
+        cardSimulator.assignToTerminal(terminal);
+
+        // connect to card
+        Card card = terminal.connect("T=1");
+        test(card);
+    }
+
+    public void testProvider() throws CardException, NoSuchAlgorithmException {
+        // register security provider
+        if (Security.getProvider("CardTerminalSimulator") == null) {
+            Security.addProvider(new CardTerminalSimulator.SecurityProvider());
+        }
+
+        // get instance
+        TerminalFactory tf = TerminalFactory.getInstance("CardTerminalSimulator", null);
+        CardTerminals terminals = tf.terminals();
+        CardTerminal terminal = terminals.getTerminal("jCardSim.Terminal");
+
+        // create and insert card
+        CardSimulator cardSimulator = new CardSimulator();
+        cardSimulator.assignToTerminal(terminal);
+
+        // connect to card
+        Card card = terminal.connect("T=1");
+        test(card);
+    }
+
+    public void testProviderCustomNames() throws CardException, NoSuchAlgorithmException {
+        // register security provider
+        if (Security.getProvider("CardTerminalSimulator") == null) {
+            Security.addProvider(new CardTerminalSimulator.SecurityProvider());
+        }
+
+        // get instance
+        TerminalFactory tf = TerminalFactory.getInstance("CardTerminalSimulator", new String[]{"x", "y"});
+        CardTerminals terminals = tf.terminals();
+        CardTerminal terminal = terminals.getTerminal("y");
+
+        // create and insert card
+        CardSimulator cardSimulator = new CardSimulator();
+        cardSimulator.assignToTerminal(terminal);
+
+        // connect to card
+        Card card = terminal.connect("T=1");
+
+        test(card);
+        assertEquals(2, terminals.list().size());
+        assertEquals("x", terminals.list().get(0).getName());
+        assertEquals("y", terminals.list().get(1).getName());
+    }
+
+    public void testWaitForInsert() throws CardException, InterruptedException {
+        final AutoResetEvent autoResetEvent = new AutoResetEvent();
+        final CardTerminals terminals = CardTerminalSimulator.terminals("my terminal");
+        final CardTerminal terminal = terminals.getTerminal("my terminal");
+        assertEquals(true, terminal.waitForCardAbsent(1));
+        assertEquals(false, terminal.waitForCardPresent(1));
+
+        final CardSimulator cardSimulator = new CardSimulator();
+        new Thread() {
+            @Override
+            public void run() {
+                cardSimulator.assignToTerminal(terminal);
+                autoResetEvent.signal();
+            }
+        }.start();
+
+        autoResetEvent.await(1, TimeUnit.MINUTES);
+        assertEquals(true, terminal.waitForCardPresent(1));
+
+        // connect to card
+        Card card = terminal.connect("T=1");
+        test(card);
+    }
+
+    public void testWaitForCardAbsent() throws CardException, InterruptedException {
+        final CardTerminals terminals = CardTerminalSimulator.terminals("my terminal");
+        final CardTerminal terminal = terminals.getTerminal("my terminal");
+
+        final CardSimulator cardSimulator = new CardSimulator();
+        cardSimulator.assignToTerminal(terminal);
+
+        assertEquals(true, terminal.waitForCardPresent(1));
+        assertEquals(false, terminal.waitForCardAbsent(1));
+
+        new Thread() {
+            @Override
+            public void run() {
+                cardSimulator.assignToTerminal(null);
+            }
+        }.start();
+
+        assertEquals(true, terminal.waitForCardAbsent(0));
+    }
+
+    public void testWaitForCardChange() throws CardException, InterruptedException {
+        final CardTerminals terminals = CardTerminalSimulator.terminals("my terminal");
+
+        final CardSimulator cardSimulator = new CardSimulator();
+        assertEquals(false, terminals.waitForChange(1));
+
+        CardTerminal terminal = terminals.getTerminal("my terminal");
+        cardSimulator.assignToTerminal(terminal);
+
+        assertEquals(true, terminals.waitForChange(1));
+        assertEquals(false, terminals.waitForChange(1));
+        cardSimulator.assignToTerminal(null);
+        assertEquals(true, terminals.waitForChange(1));
+    }
+
+    public void testList() throws CardException, InterruptedException {
+        final CardTerminals terminals = CardTerminalSimulator.terminals("1", "2", "3", "4");
+
+        CardTerminal terminal1 = terminals.getTerminal("1");
+
+        assertEquals(4, terminals.list().size());
+        assertEquals(4, terminals.list(CardTerminals.State.ALL).size());
+
+        CardSimulator cardSimulator = new CardSimulator();
+        cardSimulator.assignToTerminal(terminal1);
+        assertTrue(terminal1.isCardPresent());
+        assertEquals(3, terminals.list(CardTerminals.State.CARD_ABSENT).size());
+        assertEquals(3, terminals.list(CardTerminals.State.CARD_REMOVAL).size());
+        assertEquals(0, terminals.list(CardTerminals.State.CARD_PRESENT).size());
+        assertEquals(1, terminals.list(CardTerminals.State.CARD_INSERTION).size());
+        assertEquals(0, terminals.list(CardTerminals.State.CARD_PRESENT).size());
+
+        assertEquals(true, terminals.waitForChange(1));
+        assertEquals(1, terminals.list(CardTerminals.State.CARD_INSERTION).size());
+        assertEquals(0, terminals.list(CardTerminals.State.CARD_REMOVAL).size());
+
+        cardSimulator.assignToTerminal(null);
+        assertFalse(terminal1.isCardPresent());
+        assertEquals(true, terminals.waitForChange(1));
+
+        assertEquals(4, terminals.list(CardTerminals.State.ALL).size());
+        assertEquals(3, terminals.list(CardTerminals.State.CARD_ABSENT).size());
+        assertEquals(1, terminals.list(CardTerminals.State.CARD_REMOVAL).size());
+
+        assertEquals(0, terminals.list(CardTerminals.State.CARD_INSERTION).size());
+        assertEquals(0, terminals.list(CardTerminals.State.CARD_PRESENT).size());
+        assertEquals(4, terminals.list(CardTerminals.State.CARD_ABSENT).size());
+    }
+
+    public void testExclusive() throws CardException, InterruptedException {
+        final CardTerminal terminal = CardTerminalSimulator.terminal(new CardSimulator());
+        final AutoResetEvent autoResetEvent = new AutoResetEvent();
+        final AtomicBoolean gotException = new AtomicBoolean(false);
+
+        final CardSimulator cardSimulator = new CardSimulator();
+        cardSimulator.assignToTerminal(terminal);
+        final Card card = terminal.connect("T=1");
+        final CommandAPDU commandAPDU = new CommandAPDU(0, 0, 0, 0);
+
+        card.beginExclusive();
+        card.getBasicChannel().transmit(commandAPDU);
+
+        new Thread() {
+            @Override
+            public void run() {
+                try {
+                    card.getBasicChannel().transmit(commandAPDU);
+                } catch (CardException e) {
+                    gotException.set(true);
+                } finally {
+                    autoResetEvent.signal();
+                }
+                autoResetEvent.signal();
+            }
+        }.start();
+
+        autoResetEvent.await(1, TimeUnit.MINUTES);
+        card.endExclusive();
+    }
+
+    private void test(Card jcsCard) throws CardException {
+        assertTrue(jcsCard != null);
+        // check card ATR
+        assertEquals(jcsCard.getATR(), ETALON_ATR);
+        // check card protocol
+        assertEquals(jcsCard.getProtocol(), "T=1");
+        // get basic channel
+        CardChannel jcsChannel = jcsCard.getBasicChannel();
+        assertTrue(jcsChannel != null);
+        // create applet data = aid len (byte), aid bytes, params length (byte), param
+        byte[] aidBytes = Hex.decode(TEST_APPLET_AID);
+        byte[] createData = new byte[1 + aidBytes.length + 1 + 2 + 3];
+        createData[0] = (byte) aidBytes.length;
+        System.arraycopy(aidBytes, 0, createData, 1, aidBytes.length);
+        createData[1 + aidBytes.length] = (byte) 5;
+        createData[2 + aidBytes.length] = 0; // aid
+        createData[3 + aidBytes.length] = 0; // control
+        createData[4 + aidBytes.length] = 2; // params
+        createData[5 + aidBytes.length] = 0xF; // params
+        createData[6 + aidBytes.length] = 0xF; // params
+        CommandAPDU createApplet = new CommandAPDU(0x80, 0xb8, 0, 0, createData);
+        ResponseAPDU response = jcsChannel.transmit(createApplet);
+        assertEquals(response.getSW(), 0x9000);
+        assertEquals(true, Arrays.equals(response.getData(), aidBytes));
+        // select applet
+        CommandAPDU selectApplet = new CommandAPDU(ISO7816.CLA_ISO7816, ISO7816.INS_SELECT, 4, 0, Hex.decode(TEST_APPLET_AID));
+        response = jcsChannel.transmit(selectApplet);
+        assertEquals(response.getSW(), 0x9000);
+        // test NOP
+        response = jcsChannel.transmit(new CommandAPDU(0x01, 0x02, 0x00, 0x00));
+        assertEquals(0x9000, response.getSW());
+        // test SW_INS_NOT_SUPPORTED
+        response = jcsChannel.transmit(new CommandAPDU(0x01, 0x05, 0x00, 0x00));
+        assertEquals(ISO7816.SW_INS_NOT_SUPPORTED, response.getSW());
+        // test hello world from card
+        response = jcsChannel.transmit(new CommandAPDU(0x01, 0x01, 0x00, 0x00));
+        assertEquals(0x9000, response.getSW());
+        assertEquals("Hello world !", new String(response.getData()));
+        // test echo
+        response = jcsChannel.transmit(new CommandAPDU(0x01, 0x01, 0x01, 0x00, ("Hello javacard world !").getBytes()));
+        assertEquals(0x9000, response.getSW());
+        assertEquals("Hello javacard world !", new String(response.getData()));
+        // test echo v2
+        response = jcsChannel.transmit(new CommandAPDU(0x01, 0x03, 0x00, 0x00, ("Hello javacard world !").getBytes()));
+        assertEquals(0x9000, response.getSW());
+        assertEquals("Hello javacard world !", new String(response.getData()));
+        // test echo install params
+        response = jcsChannel.transmit(new CommandAPDU(0x01, 0x04, 0x00, 0x00));
+        assertEquals(0x9000, response.getSW());
+        assertEquals(0xF, response.getData()[0]);
+        assertEquals(0xF, response.getData()[1]);
+        // test continued data
+        response = jcsChannel.transmit(new CommandAPDU(0x01, 0x06, 0x00, 0x00));
+        assertEquals(0x6107, response.getSW());
+        assertEquals("Hello ", new String(response.getData()));
+        // test https://github.com/licel/jcardsim/issues/13
+        byte[] listObjectsCmd = new byte[5];
+        listObjectsCmd[0] = (byte) 0xb0;
+        listObjectsCmd[1] = (byte) 0x58;
+        listObjectsCmd[2] = (byte) 0x00;
+        listObjectsCmd[3] = (byte) 0x00;
+        listObjectsCmd[4] = (byte) 0x0E;
+        response = jcsChannel.transmit(new CommandAPDU(listObjectsCmd));
+        assertEquals(0x9C12, response.getSW());
+        // application specific sw + data
+        response = jcsChannel.transmit(new CommandAPDU(0x01, 0x07, 0x00, 0x00));
+        assertEquals(0x9B00, response.getSW());
+        assertEquals("Hello world !", new String(response.getData()));
+        // sending maximum data
+        response = jcsChannel.transmit(new CommandAPDU(0x01, 0x08, 0x00, 0x00));
+        assertEquals(0x9000, response.getSW());
+    }
+}


### PR DESCRIPTION
- Allows insertion and removal of cards at runtime
- Add CardSimulator class, a Simulator which can
  be assigned to a CardTerminal
- Fix threading issue in SimulatorRuntime
- Add test case for JavaCardRemoteServer
- Update documentation