### PR TITLE
Fix internaGetIncomingLength sign issue

### DIFF
--- a/src/main/java/javacard/framework/APDU.java
+++ b/src/main/java/javacard/framework/APDU.java
@@ -868,7 +868,7 @@ public final class APDU {
         if (extended) {
             return Util.getShort(buffer, (short) (ISO7816.OFFSET_LC + 1));
         }
-        return buffer[ISO7816.OFFSET_LC];
+        return  (short)(0xFF & buffer[ISO7816.OFFSET_LC]);
     }
 
     /**


### PR DESCRIPTION
- ensure that values between 128 and 254 will not be read as negative
  for non-extended APDUs