### PR TITLE
Fix AssymetricSignatureImpl behaviour wrt ISO9796_MR signatures

### DIFF
--- a/src/main/java/com/licel/jcardsim/crypto/AsymmetricSignatureImpl.java
+++ b/src/main/java/com/licel/jcardsim/crypto/AsymmetricSignatureImpl.java
@@ -56,7 +56,7 @@ public class AsymmetricSignatureImpl extends Signature implements SignatureMessa
                 engine = new ISO9796d2Signer(new RSAEngine(), new SHA1Digest());
                 break;
             case ALG_RSA_SHA_ISO9796_MR:    
-                engine = new ISO9796d2Signer(new RSAEngine(), new SHA1Digest());
+                engine = new ISO9796d2Signer(new RSAEngine(), new SHA1Digest(), true);
                 isRecovery = true;
                 break;
             case ALG_RSA_SHA_PKCS1:

--- a/src/main/java/com/licel/jcardsim/crypto/AsymmetricSignatureImpl.java
+++ b/src/main/java/com/licel/jcardsim/crypto/AsymmetricSignatureImpl.java
@@ -203,7 +203,7 @@ public class AsymmetricSignatureImpl extends Signature implements SignatureMessa
             messageLengthField.setAccessible(true);
             int messageLength = messageLengthField.getInt(engine);
             int digSize = 20;
-            int x = (digSize + messageLength) * 8 + 16 + 4 - keyBits;
+            int x = (digSize + messageLength) * 8 + 16 - keyBits;
             int mR = messageLength;
             if (x > 0) {
                 mR = messageLength - ((x + 7) / 8);


### PR DESCRIPTION
This fixes AssymetricSignatureImple thanks to two errors reported by SignatureMessageRecoveryTest test case.
