### PR TITLE
Fix case of OwnerPINProxy class name

### DIFF
--- a/src/main/java/com/licel/jcardsim/utils/JavaCardApiProcessor.java
+++ b/src/main/java/com/licel/jcardsim/utils/JavaCardApiProcessor.java
@@ -61,7 +61,7 @@ public class JavaCardApiProcessor {
         proxyExceptionClass(buildDir, "javacard.framework.TransactionException");
         proxyExceptionClass(buildDir, "javacard.framework.UserException");
         proxyClass(buildDir, "com.licel.jcardsim.framework.UtilProxy", "javacard.framework.Util", false);
-        proxyClass(buildDir, "com.licel.jcardsim.framework.OwnerPinProxy", "javacard.framework.OwnerPIN", false);
+        proxyClass(buildDir, "com.licel.jcardsim.framework.OwnerPINProxy", "javacard.framework.OwnerPIN", false);
         proxyClass(buildDir, "com.licel.jcardsim.crypto.ChecksumProxy", "javacard.security.Checksum", true);
         proxyClass(buildDir, "com.licel.jcardsim.crypto.CipherProxy", "javacardx.crypto.Cipher", true);
         proxyClass(buildDir, "com.licel.jcardsim.crypto.KeyAgreementProxy", "javacard.security.KeyAgreement", true);


### PR DESCRIPTION
Build used to fail on case-sensitive file systems