### PR TITLE
#88 - AsymmetricCipherImpl.doFinal did not reset internal bufferPos to 0

### DIFF
--- a/src/main/java/com/licel/jcardsim/crypto/AsymmetricCipherImpl.java
+++ b/src/main/java/com/licel/jcardsim/crypto/AsymmetricCipherImpl.java
@@ -100,6 +100,7 @@ public class AsymmetricCipherImpl extends Cipher {
         try {
             byte[] data = engine.processBlock(buffer, (short) 0, bufferPos);
             Util.arrayCopyNonAtomic(data, (short) 0, outBuff, outOffset, (short) data.length);
+            bufferPos = 0;
             return (short) data.length;
         } catch (InvalidCipherTextException ex) {
             CryptoException.throwIt(CryptoException.ILLEGAL_USE);


### PR DESCRIPTION
- fixes issue #88  
- doFinal calls internally update(), but doesn't reset bufferPos to 0. Therefore, two (or more) subsequent doFinal() will cause CryptoException, if sum of lengths of data to be processed for all call is more than cipher block length
- if length of two subsequent doFinal() calls is not larger than block length (and CryptoException is not emit), incorrect data will be encrypted (essentially, data1 from first call + data2 from second call)
- regression test created: testRegression_CipherDoFinal_bufferPosNotReset()