### PR TITLE
Enabled more/larger default SECG curves.

### DIFF
--- a/src/main/java/com/licel/jcardsim/crypto/ECKeyImpl.java
+++ b/src/main/java/com/licel/jcardsim/crypto/ECKeyImpl.java
@@ -250,6 +250,10 @@ public abstract class ECKeyImpl extends KeyImpl implements ECKey {
             case 131:
             case 163:
             case 193:
+            case 233:
+            case 283:
+            case 408:
+            case 571:
                 if ((keyType != KeyBuilder.TYPE_EC_F2M_PRIVATE) & (keyType != KeyBuilder.TYPE_EC_F2M_PUBLIC)) {
                     CryptoException.throwIt(CryptoException.ILLEGAL_VALUE);
                 }
@@ -259,7 +263,10 @@ public abstract class ECKeyImpl extends KeyImpl implements ECKey {
             case 128:
             case 160:
             case 192:
+            case 224:
             case 256:
+            case 384:
+            case 521:
                 if ((keyType != KeyBuilder.TYPE_EC_FP_PRIVATE) & (keyType != KeyBuilder.TYPE_EC_FP_PUBLIC)) {
                     CryptoException.throwIt(CryptoException.ILLEGAL_VALUE);
                 }

--- a/src/main/java/com/licel/jcardsim/crypto/KeyBuilderProxy.java
+++ b/src/main/java/com/licel/jcardsim/crypto/KeyBuilderProxy.java
@@ -81,28 +81,16 @@ public class KeyBuilderProxy {
 
             // ecc
             case KeyBuilder.TYPE_EC_F2M_PUBLIC:
-                if (keyLength != 113 && keyLength != 131 && keyLength != 163 && keyLength != 193) {
-                    CryptoException.throwIt(CryptoException.ILLEGAL_VALUE);
-                }
                 key = new ECPublicKeyImpl(keyType, keyLength);
                 break;
             case KeyBuilder.TYPE_EC_F2M_PRIVATE:
-                if (keyLength != 113 && keyLength != 131 && keyLength != 163 && keyLength != 193) {
-                    CryptoException.throwIt(CryptoException.ILLEGAL_VALUE);
-                }
                 key = new ECPrivateKeyImpl(keyType, keyLength);
                 break;
 
             case KeyBuilder.TYPE_EC_FP_PUBLIC:
-                if (keyLength != 112 && keyLength != 128 && keyLength != 160 && keyLength != 192 && keyLength != 256) {
-                    CryptoException.throwIt(CryptoException.ILLEGAL_VALUE);
-                }
                 key = new ECPublicKeyImpl(keyType, keyLength);
                 break;
             case KeyBuilder.TYPE_EC_FP_PRIVATE:
-                if (keyLength != 112 && keyLength != 128 && keyLength != 160 && keyLength != 192 && keyLength != 256) {
-                    CryptoException.throwIt(CryptoException.ILLEGAL_VALUE);
-                }
                 key = new ECPrivateKeyImpl(keyType, keyLength);
                 break;
 


### PR DESCRIPTION
Enabled more SECG curves from BouncyCastle, until now, only smaller curves were enabled while BouncyCastle has all the SECG curves from: http://www.secg.org/sec2-v2.pdf

Also, there is no reason to raise exceptions in KeyBuilder when the EC key sizes are not one of the few from the javacard spec. Since as the spec explicitly says: `keyLength - the key size in bits. The valid key bit lengths are key type dependent. Some common key lengths are listed above above in the LENGTH_* constants. See LENGTH_DES.`
Only some common lengths are listed, and EC keys can be generally any length.