### PR TITLE
Issue #108: Add support for missing ECDSA and RSA SHA hash lengths

### DIFF
--- a/src/main/java/com/licel/jcardsim/crypto/AsymmetricSignatureImpl.java
+++ b/src/main/java/com/licel/jcardsim/crypto/AsymmetricSignatureImpl.java
@@ -28,6 +28,10 @@ import org.bouncycastle.crypto.SignerWithRecovery;
 import org.bouncycastle.crypto.digests.MD5Digest;
 import org.bouncycastle.crypto.digests.RIPEMD160Digest;
 import org.bouncycastle.crypto.digests.SHA1Digest;
+import org.bouncycastle.crypto.digests.SHA224Digest;
+import org.bouncycastle.crypto.digests.SHA256Digest;
+import org.bouncycastle.crypto.digests.SHA384Digest;
+import org.bouncycastle.crypto.digests.SHA512Digest;
 import org.bouncycastle.crypto.engines.RSAEngine;
 import org.bouncycastle.crypto.signers.DSADigestSigner;
 import org.bouncycastle.crypto.signers.ECDSASigner;
@@ -62,6 +66,18 @@ public class AsymmetricSignatureImpl extends Signature implements SignatureMessa
             case ALG_RSA_SHA_PKCS1:
                 engine = new RSADigestSigner(new SHA1Digest());
                 break;
+            case ALG_RSA_SHA_224_PKCS1:
+                engine = new RSADigestSigner(new SHA224Digest());
+                break;
+            case ALG_RSA_SHA_256_PKCS1:
+                engine = new RSADigestSigner(new SHA256Digest());
+                break;
+            case ALG_RSA_SHA_384_PKCS1:
+                engine = new RSADigestSigner(new SHA384Digest());
+                break;
+            case ALG_RSA_SHA_512_PKCS1:
+                engine = new RSADigestSigner(new SHA512Digest());
+                break;
             case ALG_RSA_MD5_PKCS1:
                 engine = new RSADigestSigner(new MD5Digest());
                 break;
@@ -73,6 +89,18 @@ public class AsymmetricSignatureImpl extends Signature implements SignatureMessa
                 break;
             case ALG_ECDSA_SHA:
                 engine = new DSADigestSigner(new ECDSASigner(), new SHA1Digest());
+                break;
+            case ALG_ECDSA_SHA_224:
+                engine = new DSADigestSigner(new ECDSASigner(), new SHA224Digest());
+                break;
+            case ALG_ECDSA_SHA_256:
+                engine = new DSADigestSigner(new ECDSASigner(), new SHA256Digest());
+                break;
+            case ALG_ECDSA_SHA_384:
+                engine = new DSADigestSigner(new ECDSASigner(), new SHA384Digest());
+                break;
+            case ALG_ECDSA_SHA_512:
+                engine = new DSADigestSigner(new ECDSASigner(), new SHA512Digest());
                 break;
         }
     }
@@ -106,11 +134,19 @@ public class AsymmetricSignatureImpl extends Signature implements SignatureMessa
         switch (algorithm) {
             case ALG_RSA_SHA_ISO9796:
             case ALG_RSA_SHA_PKCS1:
+            case ALG_RSA_SHA_224_PKCS1:
+            case ALG_RSA_SHA_256_PKCS1:
+            case ALG_RSA_SHA_384_PKCS1:
+            case ALG_RSA_SHA_512_PKCS1:
             case ALG_RSA_MD5_PKCS1:
             case ALG_RSA_RIPEMD160_ISO9796:
             case ALG_RSA_RIPEMD160_PKCS1:
                 return (short)(key.getSize()>>3);
             case ALG_ECDSA_SHA:
+            case ALG_ECDSA_SHA_256:
+            case ALG_ECDSA_SHA_224:
+            case ALG_ECDSA_SHA_384:
+            case ALG_ECDSA_SHA_512:
                 // x,y + der payload
                 return (short)(((key.getSize()*2)>>3) + 8);
         }

--- a/src/main/java/com/licel/jcardsim/crypto/SignatureProxy.java
+++ b/src/main/java/com/licel/jcardsim/crypto/SignatureProxy.java
@@ -45,11 +45,19 @@ public class SignatureProxy {
         switch (algorithm) {
             case Signature.ALG_RSA_SHA_ISO9796:
             case Signature.ALG_RSA_SHA_PKCS1:
+            case Signature.ALG_RSA_SHA_224_PKCS1:
+            case Signature.ALG_RSA_SHA_256_PKCS1:
+            case Signature.ALG_RSA_SHA_384_PKCS1:
+            case Signature.ALG_RSA_SHA_512_PKCS1:
             case Signature.ALG_RSA_MD5_PKCS1:
             case Signature.ALG_RSA_RIPEMD160_ISO9796:
             case Signature.ALG_RSA_RIPEMD160_PKCS1:
             case Signature.ALG_ECDSA_SHA:
-            case Signature.ALG_RSA_SHA_ISO9796_MR:    
+            case Signature.ALG_ECDSA_SHA_224:
+            case Signature.ALG_ECDSA_SHA_256:
+            case Signature.ALG_ECDSA_SHA_384:
+            case Signature.ALG_ECDSA_SHA_512:
+            case Signature.ALG_RSA_SHA_ISO9796_MR:
                 instance = new AsymmetricSignatureImpl(algorithm);
                 break;
             case Signature.ALG_DES_MAC4_NOPAD:

--- a/src/test/java/com/licel/jcardsim/crypto/AsymmetricSignatureImplTest.java
+++ b/src/test/java/com/licel/jcardsim/crypto/AsymmetricSignatureImplTest.java
@@ -104,21 +104,73 @@ public class AsymmetricSignatureImplTest extends TestCase {
     /**
      * SelfTest of RSA sign/verify method, of class AsymmetricSignatureImpl.
      */
-    public void testSelfSignVerifyRSA() {
-        System.out.println("self test sign/verify rsa");
+    public void testSelfSignVerifyRSASHA1() {
+        System.out.println("self test sign/verify rsa SHA1");
         testSelfSignVerify(KeyPair.ALG_RSA_CRT, RSA_ETALON_KEY_SIZE, Signature.ALG_RSA_SHA_PKCS1);
+    }
+    
+    public void testSelfSignVerifyRSASHA224() {
+        System.out.println("self test sign/verify rsa SHA-224");
+        testSelfSignVerify(KeyPair.ALG_RSA_CRT, RSA_ETALON_KEY_SIZE, Signature.ALG_RSA_SHA_224_PKCS1);
+    }
+
+    public void testSelfSignVerifyRSASHA256() {
+        System.out.println("self test sign/verify rsa SHA-256");
+        testSelfSignVerify(KeyPair.ALG_RSA_CRT, RSA_ETALON_KEY_SIZE, Signature.ALG_RSA_SHA_256_PKCS1);
+    }
+
+    public void testSelfSignVerifyRSASHA384() {
+        System.out.println("self test sign/verify rsa SHA-384");
+        testSelfSignVerify(KeyPair.ALG_RSA_CRT, RSA_ETALON_KEY_SIZE, Signature.ALG_RSA_SHA_384_PKCS1);
+    }
+
+    public void testSelfSignVerifyRSASHA512() {
+        System.out.println("self test sign/verify rsa SHA-512");
+        testSelfSignVerify(KeyPair.ALG_RSA_CRT, RSA_ETALON_KEY_SIZE, Signature.ALG_RSA_SHA_512_PKCS1);
     }
 
    
     /**
      * SelfTest of ECDSA sign/verify method, of class AsymmetricSignatureImpl.
      */
-    public void testSelfSignVerifyECDSA() {
-        System.out.println("self test sign/verify ecdsa");
+    public void testSelfSignVerifyECDSASHA1() {
+        System.out.println("self test sign/verify ecdsa SHA1");
         // ecf2m keys
         testSelfSignVerify(KeyPair.ALG_EC_F2M, KeyBuilder.LENGTH_EC_F2M_113, Signature.ALG_ECDSA_SHA);
         // ecfp keys
         testSelfSignVerify(KeyPair.ALG_EC_FP, KeyBuilder.LENGTH_EC_FP_112, Signature.ALG_ECDSA_SHA);
+    }
+
+    public void testSelfSignVerifyECDSASHA224() {
+        System.out.println("self test sign/verify ecdsa SHA-224");
+        // ecf2m keys
+        testSelfSignVerify(KeyPair.ALG_EC_F2M, KeyBuilder.LENGTH_EC_F2M_113, Signature.ALG_ECDSA_SHA_224);
+        // ecfp keys
+        testSelfSignVerify(KeyPair.ALG_EC_FP, KeyBuilder.LENGTH_EC_FP_112, Signature.ALG_ECDSA_SHA_224);
+    }
+
+    public void testSelfSignVerifyECDSASHA256() {
+        System.out.println("self test sign/verify ecdsa SHA-256");
+        // ecf2m keys
+        testSelfSignVerify(KeyPair.ALG_EC_F2M, KeyBuilder.LENGTH_EC_F2M_113, Signature.ALG_ECDSA_SHA_256);
+        // ecfp keys
+        testSelfSignVerify(KeyPair.ALG_EC_FP, KeyBuilder.LENGTH_EC_FP_112, Signature.ALG_ECDSA_SHA_256);
+    }
+
+    public void testSelfSignVerifyECDSASHA384() {
+        System.out.println("self test sign/verify ecdsa SHA-384");
+        // ecf2m keys
+        testSelfSignVerify(KeyPair.ALG_EC_F2M, KeyBuilder.LENGTH_EC_F2M_113, Signature.ALG_ECDSA_SHA_384);
+        // ecfp keys
+        testSelfSignVerify(KeyPair.ALG_EC_FP, KeyBuilder.LENGTH_EC_FP_112, Signature.ALG_ECDSA_SHA_384);
+    }
+
+    public void testSelfSignVerifyECDSASHA512() {
+        System.out.println("self test sign/verify ecdsa SHA-512");
+        // ecf2m keys
+        testSelfSignVerify(KeyPair.ALG_EC_F2M, KeyBuilder.LENGTH_EC_F2M_113, Signature.ALG_ECDSA_SHA_512);
+        // ecfp keys
+        testSelfSignVerify(KeyPair.ALG_EC_FP, KeyBuilder.LENGTH_EC_FP_112, Signature.ALG_ECDSA_SHA_512);
     }
 
     /**


### PR DESCRIPTION
These modifications add support for the following signatures:
- ALG_ECDSA_SHA_224
- ALG_ECDSA_SHA_256
- ALG_ECDSA_SHA_384
- ALG_ECDSA_SHA_512
- ALG_RSA_SHA_224_PKCS1
- ALG_RSA_SHA_256_PKCS1
- ALG_RSA_SHA_384_PKCS1
- ALG_RSA_SHA_512_PKCS1

Test cases have been added to cover the changes. 