### PR TITLE
Added resize of ByteContainer for longer buffer

### DIFF
--- a/src/main/java/com/licel/jcardsim/crypto/ByteContainer.java
+++ b/src/main/java/com/licel/jcardsim/crypto/ByteContainer.java
@@ -106,7 +106,7 @@ public final class ByteContainer {
      * @param length length of data in byte array
      */
     public void setBytes(byte[] buff, short offset, short length) {
-        if (data == null) {
+        if (data == null || (short) data.length < length) {
             switch (memoryType) {
                 case JCSystem.MEMORY_TYPE_TRANSIENT_DESELECT:
                     data = JCSystem.makeTransientByteArray(length, JCSystem.CLEAR_ON_DESELECT);

--- a/src/test/java/com/licel/jcardsim/crypto/ByteContainerTest.java
+++ b/src/test/java/com/licel/jcardsim/crypto/ByteContainerTest.java
@@ -3,6 +3,7 @@ package com.licel.jcardsim.crypto;
 import junit.framework.TestCase;
 
 import java.math.BigInteger;
+import javacard.framework.JCSystem;
 
 public class ByteContainerTest extends TestCase {
     public ByteContainerTest(String name) {
@@ -52,4 +53,23 @@ public class ByteContainerTest extends TestCase {
 
         assertEquals(expected, new ByteContainer(expected).getBigInteger());
     }
+    
+    public void testSetBytes() {
+        short TEST_DATA_LEN = (short) 32;
+        byte[] expected = new byte[TEST_DATA_LEN];
+        ByteContainer container = new ByteContainer(expected, (short) 0, (short) expected.length);
+        byte[] dataResult = container.getBytes(JCSystem.MEMORY_TYPE_TRANSIENT_RESET);
+        assertEquals(expected.length, dataResult.length);
+        
+        // Try to set with shorter and longer array - length should change accordingly
+        byte[] shorter = new byte[(short) (TEST_DATA_LEN - 2)];
+        container.setBytes(shorter);
+        dataResult = container.getBytes(JCSystem.MEMORY_TYPE_TRANSIENT_RESET);
+        assertEquals(shorter.length, dataResult.length);
+        byte[] longer = new byte[(short) (TEST_DATA_LEN + 2)];
+        container.setBytes(longer);
+        dataResult = container.getBytes(JCSystem.MEMORY_TYPE_TRANSIENT_RESET);
+        assertEquals(longer.length, dataResult.length);
+    }
+    
 }


### PR DESCRIPTION
ByteContainer is resized if longer buffer than currently allocated is provided in setBytes(). Caused ArrayIndexOutOfBoundsException previously 