### PR TITLE
Javadoc fixes for jdk1.8

### DIFF
--- a/src/main/java/com/licel/jcardsim/crypto/CipherProxy.java
+++ b/src/main/java/com/licel/jcardsim/crypto/CipherProxy.java
@@ -25,7 +25,7 @@ public class CipherProxy {
     /**
      * Creates a <code>Cipher</code> object instance of the selected algorithm.
      * @param algorithm the desired Cipher algorithm. Valid codes listed in
-     * ALG_ .. constants above, for example, {@link #ALG_DES_CBC_NOPAD}
+     * ALG_ .. constants above, for example, {@link Cipher#ALG_DES_CBC_NOPAD}
      * @param externalAccess indicates that the instance will be shared among
      * multiple applet instances and that the <code>Cipher</code> instance will also be accessed (via a <code>Shareable</code>
      * interface) when the owner of the <code>Cipher</code> instance is not the currently selected applet.

--- a/src/main/java/com/licel/jcardsim/crypto/KeyBuilderProxy.java
+++ b/src/main/java/com/licel/jcardsim/crypto/KeyBuilderProxy.java
@@ -30,10 +30,10 @@ public class KeyBuilderProxy {
      * <code>Signature</code>, <code>Cipher</code> and <code>KeyPair</code>.
      * Note that the object returned must be cast to their appropriate key type interface.
      * @param keyType the type of key to be generated. Valid codes listed in TYPE.. constants.
-     * See {@link #TYPE_DES_TRANSIENT_RESET}.
+     * See {@link KeyBuilder#TYPE_DES_TRANSIENT_RESET}.
      * @param keyLength the key size in bits. The valid key bit lengths are key type dependent. Some common
      * key lengths are listed above above in the LENGTH_.. constants.
-     * See {@link #LENGTH_DES}.
+     * See {@link KeyBuilder#LENGTH_DES}.
      * @param keyEncryption if <code>true</code> this boolean requests a key implementation
      * which implements the <code>javacardx.crypto.KeyEncryption</code> interface.
      * The key implementation returned may implement the <code>javacardx.crypto.KeyEncryption</code>

--- a/src/main/java/com/licel/jcardsim/crypto/KeyPairProxy.java
+++ b/src/main/java/com/licel/jcardsim/crypto/KeyPairProxy.java
@@ -21,7 +21,7 @@ import javacard.security.PublicKey;
 
 /**
  * ProxyClass for <code>KeyPair</code>
- * @see KeyPair
+ * @see javacard.security.KeyPair
  */
 
 public class KeyPairProxy {
@@ -53,11 +53,11 @@ public class KeyPairProxy {
      * the Field, A, B, G and R parameter set in EC is invalid.
      * </ul>
      * @see javacard.framework.APDU
-     * @see Signature
+     * @see javacard.security.Signature
      * @see javacardx.crypto.Cipher
-     * @see RSAPublicKey
-     * @see ECKey
-     * @see DSAKey
+     * @see javacard.security.RSAPublicKey
+     * @see javacard.security.ECKey
+     * @see javacard.security.DSAKey
      */
     public final void genKeyPair()
             throws CryptoException {
@@ -80,12 +80,12 @@ public class KeyPairProxy {
      * Valid codes listed in <code>ALG_..</code> constants above. See <A HREF="../../javacard/security/KeyPair.html#ALG_RSA"><CODE>ALG_RSA</CODE></A>
      * @param keyLength  the key size in bits. The valid key bit lengths are key type dependent.
      * See the <code>KeyBuilder</code> class.
-     * @see KeyBuilder
+     * @see javacard.security.KeyBuilder
      * @throws CryptoException with the following reason codes:<ul>
      * <li><code>CryptoException.NO_SUCH_ALGORITHM</code> if the requested algorithm
      * associated with the specified type, size of key is not supported.</ul>
-     * @see KeyBuilder
-     * @see Signature
+     * @see javacard.security.KeyBuilder
+     * @see javacard.security.Signature
      * @see javacardx.crypto.KeyEncryption
      * @see javacardx.crypto.Cipher
      */

--- a/src/main/java/com/licel/jcardsim/crypto/MessageDigestProxy.java
+++ b/src/main/java/com/licel/jcardsim/crypto/MessageDigestProxy.java
@@ -52,7 +52,7 @@ public class MessageDigestProxy {
      * <p>
      *
      * @param algorithm the desired message digest algorithm. Valid codes listed in ALG_* constants above,
-     * for example, {@link #ALG_SHA}.
+     * for example, {@link MessageDigest#ALG_SHA}.
      * @param externalAccess true indicates that the instance will be shared among multiple applet 
      * instances and that the <code>InitializedMessageDigest</code> instance will also be accessed (via a <code>Shareable</code>. interface) 
      * when the owner of the <code>InitializedMessageDigest</code> instance is not the currently selected applet. 

--- a/src/main/java/com/licel/jcardsim/framework/AIDProxy.java
+++ b/src/main/java/com/licel/jcardsim/framework/AIDProxy.java
@@ -20,7 +20,7 @@ import javacard.framework.Util;
 
 /**
  * ProxyClass for <code>AID</code>
- * @see AID
+ * @see javacard.framework.AID
  */
 public class AIDProxy {
     byte aid[];

--- a/src/main/java/com/licel/jcardsim/framework/APDUProxy.java
+++ b/src/main/java/com/licel/jcardsim/framework/APDUProxy.java
@@ -500,7 +500,7 @@ public class APDUProxy {
      * <CODE>APDU</CODE> object. It is used by the <CODE>BasicService</CODE> class to help
      * services collaborate in the processing of an incoming APDU command.
      * Valid codes are listed in STATE_ .. constants above.
-     * @see #STATE_INITIAL
+     * @see APDU#STATE_INITIAL
      * @return the current processing state of the APDU
      */
     public byte getCurrentState() {

--- a/src/main/java/com/licel/jcardsim/framework/CardExceptionProxy.java
+++ b/src/main/java/com/licel/jcardsim/framework/CardExceptionProxy.java
@@ -17,7 +17,7 @@ package com.licel.jcardsim.framework;
 
 /**
  * ProxyClass for <code>CardException</code>
- * @see CardException
+ * @see javacard.framework.CardException
  */
 public class CardExceptionProxy extends Exception {
 

--- a/src/main/java/com/licel/jcardsim/framework/CardRuntimeExceptionProxy.java
+++ b/src/main/java/com/licel/jcardsim/framework/CardRuntimeExceptionProxy.java
@@ -17,7 +17,7 @@ package com.licel.jcardsim.framework;
 
 /**
  * ProxyClass for <code>CardRuntimeException</code>
- * @see CardRuntimeException
+ * @see javacard.framework.CardRuntimeException
  */
 public class CardRuntimeExceptionProxy extends RuntimeException {
 

--- a/src/main/java/com/licel/jcardsim/framework/JCSystemProxy.java
+++ b/src/main/java/com/licel/jcardsim/framework/JCSystemProxy.java
@@ -367,7 +367,7 @@ public class JCSystemProxy {
      * @param serverAID the AID of the server applet
      * @param parameter optional parameter data
      * @return the shareable interface object or <code>null</code>
-     * @see Applet#getShareableInterfaceObject(AID, byte)
+     * @see javacard.framework.Applet#getShareableInterfaceObject(AID, byte)
      */
     public static Shareable getAppletShareableInterfaceObject(AID serverAID, byte parameter) {
         return SimulatorSystem.instance().getSharedObject(serverAID, parameter);

--- a/src/main/java/com/licel/jcardsim/framework/OwnerPINProxy.java
+++ b/src/main/java/com/licel/jcardsim/framework/OwnerPINProxy.java
@@ -22,7 +22,7 @@ import javacard.framework.Util;
 
 /**
  * Implementation for <code>OwnerPin</code>
- * @see OwnerPin
+ * @see javacard.framework.OwnerPIN
  */
 
 public class OwnerPINProxy implements PIN {

--- a/src/main/java/com/licel/jcardsim/framework/UtilProxy.java
+++ b/src/main/java/com/licel/jcardsim/framework/UtilProxy.java
@@ -19,7 +19,7 @@ import javacard.framework.TransactionException;
 
 /**
  * ProxyClass for <code>Util</code>
- * @see Util
+ * @see javacard.framework.Util
  */
 public class UtilProxy {
     /**
@@ -58,8 +58,8 @@ public class UtilProxy {
      * @return destOff+length
      * @throws ArrayIndexOutOfBoundsException if copying would cause access of data outside array bounds
      * @throws NullPointerException if either <code>src</code> or <code>dest</code> is <code>null</code>
-     * @throws TransactionExceptionImpl f copying would cause the commit capacity to be exceeded
-     * @see JCSystem#getUnusedCommitCapacity()
+     * @throws TransactionException if copying would cause the commit capacity to be exceeded
+     * @see javacard.framework.JCSystem#getUnusedCommitCapacity()
      */
     public static final short arrayCopy(byte src[], short srcOff, byte dest[], short destOff, short length)
             throws ArrayIndexOutOfBoundsException, NullPointerException, TransactionException {
@@ -104,8 +104,8 @@ public class UtilProxy {
      * @return destOff+length
      * @throws ArrayIndexOutOfBoundsException if copying would cause access of data outside array bounds
      * @throws NullPointerException if either <code>src</code> or <code>dest</code> is <code>null</code>
-     * @throws TransactionExceptionImpl f copying would cause the commit capacity to be exceeded
-     * @see JCSystem#getUnusedCommitCapacity()
+     * @throws TransactionException if copying would cause the commit capacity to be exceeded
+     * @see javacard.framework.JCSystem#getUnusedCommitCapacity()
      */
     public static final short arrayCopyNonAtomic(byte src[], short srcOff, byte dest[], short destOff, short length)
             throws ArrayIndexOutOfBoundsException, NullPointerException {
@@ -138,7 +138,7 @@ public class UtilProxy {
      * @return bOff+bLen
      * @throws ArrayIndexOutOfBoundsException if the fill operation would cause access of data outside array bounds
      * @throws NullPointerException if bArray is <code>null</code>
-     * @see JCSystem#getUnusedCommitCapacity()
+     * @see javacard.framework.JCSystem#getUnusedCommitCapacity()
      */
     public static final short arrayFillNonAtomic(byte bArray[], short bOff, short bLen, byte bValue)
             throws ArrayIndexOutOfBoundsException, NullPointerException {
@@ -237,8 +237,8 @@ public class UtilProxy {
      * @throws ArrayIndexOutOfBoundsException if the <CODE>bOff</CODE> parameter is negative or if <CODE>bOff+2</CODE> is greater than the length of <code>bArray</code>
      * of <CODE>bArray</CODE>
      * @throws NullPointerException if the <CODE>bArray</CODE> parameter is <CODE>null</CODE>
-     * @throws TransactionExceptionImpl if the operation would cause the commit capacity to be exceeded
-     * @see JCSystem#getUnusedCommitCapacity()
+     * @throws TransactionException if the operation would cause the commit capacity to be exceeded
+     * @see javacard.framework.JCSystem#getUnusedCommitCapacity()
      */
     public static final short setShort(byte bArray[], short bOff, short sValue)
             throws TransactionException, ArrayIndexOutOfBoundsException, NullPointerException {


### PR DESCRIPTION
- Fixes all javadoc warnings found by maven javadoc:javadoc task
- Javadoc warnings fail the javadoc task in Java 8