### PR TITLE
Add some support for new RandomData algorithms.

### DIFF
--- a/src/main/java/com/licel/jcardsim/crypto/RandomDataImpl.java
+++ b/src/main/java/com/licel/jcardsim/crypto/RandomDataImpl.java
@@ -28,11 +28,12 @@ import org.bouncycastle.crypto.prng.RandomGenerator;
  * @see RandomData
  */
 public class RandomDataImpl extends RandomData {
-
+    byte algorithm;
     RandomGenerator engine;
 
-    public RandomDataImpl() {
-        engine = new DigestRandomGenerator(new SHA1Digest());
+    public RandomDataImpl(byte algorithm) {
+        this.algorithm = algorithm;
+        this.engine = new DigestRandomGenerator(new SHA1Digest());
     }
 
     public void generateData(byte[] buffer, short offset, short length) throws CryptoException {
@@ -44,10 +45,13 @@ public class RandomDataImpl extends RandomData {
         Util.arrayCopyNonAtomic(buffer, offset, seed, (short) 0, length);
         engine.addSeedMaterial(seed);
     }
+
     public byte getAlgorithm() {
-        throw new UnsupportedOperationException("Not supported yet.");
+        return algorithm;
     }
-    public short nextBytes(byte[] bytes, short s, short s1) throws CryptoException {
-        throw new UnsupportedOperationException("Not supported yet.");
+
+    public short nextBytes(byte[] buffer, short offset, short length) throws CryptoException {
+        engine.nextBytes(buffer, offset, length);
+        return (short) (offset + length);
     }
 }

--- a/src/main/java/com/licel/jcardsim/crypto/RandomDataProxy.java
+++ b/src/main/java/com/licel/jcardsim/crypto/RandomDataProxy.java
@@ -19,6 +19,9 @@ import javacard.security.CryptoException;
 import javacard.security.RandomData;
 import static javacard.security.RandomData.ALG_PSEUDO_RANDOM;
 import static javacard.security.RandomData.ALG_SECURE_RANDOM;
+import static javacard.security.RandomData.ALG_TRNG;
+import static javacard.security.RandomData.ALG_FAST;
+import static javacard.security.RandomData.ALG_KEYGENERATION;
 
 /**
  * ProxyClass for <code>RandomData</code>
@@ -38,8 +41,11 @@ public class RandomDataProxy {
         RandomData instance = null;
         switch (algorithm) {
             case ALG_PSEUDO_RANDOM: 
-            case ALG_SECURE_RANDOM: 
-                instance = new RandomDataImpl();
+            case ALG_SECURE_RANDOM:
+            case ALG_TRNG:
+            case ALG_FAST:
+            case ALG_KEYGENERATION:
+                instance = new RandomDataImpl(algorithm);
                 break;
             default:
                 CryptoException.throwIt((short) 3);

--- a/src/test/java/com/licel/jcardsim/crypto/RandomDataImplTest.java
+++ b/src/test/java/com/licel/jcardsim/crypto/RandomDataImplTest.java
@@ -45,6 +45,30 @@ public class RandomDataImplTest extends TestCase {
         instance.generateData(buffer, (short) 0, (short) buffer.length);
         instance = RandomData.getInstance(RandomData.ALG_SECURE_RANDOM);
         instance.generateData(buffer, (short) 0, (short) buffer.length);
+        instance = RandomData.getInstance(RandomData.ALG_TRNG);
+        instance.generateData(buffer, (short) 0, (short) buffer.length);
+        instance = RandomData.getInstance(RandomData.ALG_FAST);
+        instance.generateData(buffer, (short) 0, (short) buffer.length);
+        instance = RandomData.getInstance(RandomData.ALG_KEYGENERATION);
+        instance.generateData(buffer, (short) 0, (short) buffer.length);
+    }
+
+    /**
+     * Test of generateData method, of class RandomDataImpl.
+     */
+    public void testNextBytes() {
+        System.out.println("nextBytes");
+        byte[] buffer = new byte[8];
+        RandomData instance = RandomData.getInstance(RandomData.ALG_PSEUDO_RANDOM);
+        instance.nextBytes(buffer, (short) 0, (short) buffer.length);
+        instance = RandomData.getInstance(RandomData.ALG_SECURE_RANDOM);
+        instance.nextBytes(buffer, (short) 0, (short) buffer.length);
+        instance = RandomData.getInstance(RandomData.ALG_TRNG);
+        instance.nextBytes(buffer, (short) 0, (short) buffer.length);
+        instance = RandomData.getInstance(RandomData.ALG_FAST);
+        instance.nextBytes(buffer, (short) 0, (short) buffer.length);
+        instance = RandomData.getInstance(RandomData.ALG_KEYGENERATION);
+        instance.nextBytes(buffer, (short) 0, (short) buffer.length);
     }
 
     /**
@@ -57,6 +81,15 @@ public class RandomDataImplTest extends TestCase {
         instance.setSeed(buffer, (short) 0, (short) buffer.length);
         instance.generateData(buffer, (short) 0, (short) buffer.length);
         instance = RandomData.getInstance(RandomData.ALG_SECURE_RANDOM);
+        instance.setSeed(buffer, (short) 0, (short) buffer.length);
+        instance.generateData(buffer, (short) 0, (short) buffer.length);
+        instance = RandomData.getInstance(RandomData.ALG_TRNG);
+        instance.setSeed(buffer, (short) 0, (short) buffer.length);
+        instance.generateData(buffer, (short) 0, (short) buffer.length);
+        instance = RandomData.getInstance(RandomData.ALG_FAST);
+        instance.setSeed(buffer, (short) 0, (short) buffer.length);
+        instance.generateData(buffer, (short) 0, (short) buffer.length);
+        instance = RandomData.getInstance(RandomData.ALG_KEYGENERATION);
         instance.setSeed(buffer, (short) 0, (short) buffer.length);
         instance.generateData(buffer, (short) 0, (short) buffer.length);
     }


### PR DESCRIPTION
JavaCard 3.0.5 has some more `RandomData` algorithm types. This PR adds naive support for those, this is ok as the behavior of these algorithms is implementation dependent anyway, so implementing them all in the same way in JCardSim is not a problem.