### PR TITLE
Improve build instructions and documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
                             <artifactId>api_classic</artifactId>
                             <version>${jcApiVersion}</version>
                             <packaging>jar</packaging>
-                            <file>${jcdkLocation}/lib/api_classic.jar</file>
+                            <file>${env.JC_CLASSIC_HOME}/lib/api_classic.jar</file>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,9 @@
                 </executions>
             </plugin>
 	    <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
         	<artifactId>maven-surefire-plugin</artifactId>
+                <version>2.21.0</version>
 		<configuration>
 		    <argLine>-noverify</argLine>
 		</configuration>

--- a/sitedocs/getting_source_and_compiling.md
+++ b/sitedocs/getting_source_and_compiling.md
@@ -1,38 +1,28 @@
-jCardSim is an open source project and it would be pleasure for us to see you as commiters and contributors!
+## Building & Development
 
 ### Source code
 The official jCardSim source repository is located at [https://github.com/licel/jcardsim](https://github.com/licel/jcardsim).
 
 
 ### Building
-1. jCardSim does not contain any Oracle's Java Card API source code, because of that it is needed to download JCDK from Oracle’s site and unpack it.
-2. Set `jcdkLocation` property in `~/.m2/settings.xml` (profiles - profile). The settings.xml file is located in ${user.home}/.m2 (https://maven.apache.org/settings.html) and contains all the local Maven settings. For example:
+**NOTE:** jCardSim must be built on Windows, because the JCDK is no longer packaged for other platforms. However, the JAR files produced by the build are still cross-platform.
 
-~~~xml
-<?xml version="1.0" encoding="UTF-8"?>
-<settings>
-  <profiles>
-    <profile>
-        <id>jc304</id>
-        <activation>
-          <activeByDefault>true</activeByDefault>
-        </activation>
-        <properties>
-          <jcdkLocation>/Users/developer/jcdk304</jcdkLocation>
-        </properties>
-    </profile>
-  </profiles>
-</settings>
-~~~
+1. Install the [Java Development Kit (JDK) 8](http://www.oracle.com/technetwork/java/javase/downloads/) from Oracle.
 
-3. We use [Maven](http://http://maven.apache.org/) for building. After downloading the source code, you have to enter the directory with jCardSim and execute the following commands:
+2. Install the [Java Card Classic Development Kit](http://www.oracle.com/technetwork/java/embedded/javacard/downloads/) from Oracle, which provides the Java Card API classes. The installer should automatically set the `JC_CLASSIC_HOME` environment variable system-wide.
 
-~~~
+3. Install [Apache Maven](https://maven.apache.org/download.html), which is used to build jCardSim. Follow the [installation tips](https://maven.apache.org/install.html) to set the `PATH` and `JAVA_HOME` environment variables.
+
+4. From the directory containing the jCardSim source code, execute the following commands:
+    ~~~
     mvn initialize
     mvn clean install
-~~~
+    ~~~
 
-### Development standards
+
+### Development
+jCardSim is an open source project, and it would be a pleasure for us to see you as committers and contributors!
+
 We are using the following principles in jCardSim's development process:
 
 - [Test-Driven Development](http://en.wikipedia.org/wiki/Test-driven_development)

--- a/sitedocs/quick_start_guide_simulator_api.md
+++ b/sitedocs/quick_start_guide_simulator_api.md
@@ -1,14 +1,12 @@
-jCardSim is intended for rapid prototyping of Java Card applications and unit testing.
+## Quick Start Guide: API
 
-There are three ways to use the simulator:
+jCardSim provides an API for rapid prototyping of Java Card applications and unit testing. There are three different ways it can be used:
 
- - Using the Simulator API
- - Using the `javax.smartcardio` API
- - Using the remote API
+ - the `CardSimulator` class
+ - the `CardTerminalSimulator` class (for applications that use `javax.smartcardio`)
+ - the `JavaCardRemoteInterface` interface
 
-### Using the Simulator API
-
-Working with the simulator:
+### Using the `CardSimulator` class
 
 	// 1. Create simulator
 	CardSimulator simulator = new CardSimulator();
@@ -27,7 +25,11 @@ Working with the simulator:
 	// 5. Check response status word
 	assertEquals(0x9000, response.getSW());
 
-An example of how to work with `HelloWorldApplet` from the first part of [Quick Start Guide: Using in CLI mode](http://jcardsim.org/docs/quick-start-guide-using-in-cli-mode):
+The example below uses [`HelloWorldApplet`](https://github.com/licel/jcardsim/blob/master/src/main/java/com/licel/jcardsim/samples/HelloWorldApplet.java), which responds to command APDUs as follows:
+
+ - `CLA=0x00 INS=0x02 P1=0x00 P2=0x00 LC=0x00`: do nothing
+ - `CLA=0x00 INS=0x01 P1=0x00 P2=0x00 LC=0x00`: return the bytes in "Hello world !"
+ - `CLA=0x00 INS=0x01 P1=0x01 P2=0x00 LC=<length> DATA=<data>`: return the command data (echo)
 
 	CardSimulator simulator = new CardSimulator();
 
@@ -77,12 +79,9 @@ To simplify the handling of AIDs and byte arrays we provide `AIDUtil` and `ByteU
 	assertEquals("00020000", hexString);
 	assertEquals("00020000", ByteUtil.hexString(bytes));
 
-### Using `javax.smartcardio` for an interaction with JavaCard
+### Using the `CardTerminalSimulator` class
 
-To simplify unit testing of applications that use `javax.smartcardio`,
-we provide a simulated `TerminalFactory` via `CardTerminalSimulator`.
-
-Using the `CardSimulator` via the `CardTerminal` API:
+To simplify unit testing of applications that use `javax.smartcardio`, we provide a `CardTerminalSimulator` class that simulates `javax.smartcardio.TerminalFactory`.
 
 	// 1. Create simulator and install applet
 	CardSimulator simulator = new CardSimulator();
@@ -107,14 +106,14 @@ Using the `CardSimulator` via the `CardTerminal` API:
 	// 6. Check response status word
 	assertEquals(0x9000, response.getSW());
 
-> **Note:** Pre-installed applets can be configured using system properties: `System.setProperty(...)`, the format is equal to the configuration file of the CLI mode of jCardSim.
+**Note:** Pre-installed applets can be configured using system properties: `System.setProperty(...)`.
+Properties follow the same format used in the [CLI configuration file](https://github.com/licel/jcardsim/blob/master/jcardsim.cfg).
 
-It is also possible to simulate multiple terminals using `CardTerminals`.
-In this case each `CardTerminal` starts in an empty state (`isCardPresent()` returns `false`).
+It is also possible to simulate multiple terminals using `javax.smartcardio.CardTerminals`.
+In this case each `javax.smartcardio.CardTerminal` starts in an empty state (`isCardPresent()` returns `false`).
 Cards can be inserted via `CardSimulator#assignToTerminal(terminal)` and removed via
 `CardSimulator#assignToTerminal(null)`.
 
-Working with `CardTerminals`:
 
 	// Obtain CardTerminal
 	CardTerminals cardTerminals = CardTerminalSimulator.terminals("My terminal 1", "My terminal 2");
@@ -134,7 +133,7 @@ Working with `CardTerminals`:
 	assertEquals(true,  terminal1.isCardPresent());
 	assertEquals(false, terminal2.isCardPresent());
 
-Creating a terminal via the `TerminalFactory` API:
+Creating a terminal via `javax.smartcardio.TerminalFactory`:
 
 	// Register security provider
 	if (Security.getProvider("CardTerminalSimulator") == null) {
@@ -153,7 +152,7 @@ Creating a terminal via the `TerminalFactory` API:
 	// Insert Card
 	simulator.assignToTerminal(terminal);
 
-Creating multiple terminals via the `TerminalFactory` API:
+Creating multiple terminals via `javax.smartcardio.TerminalFactory`:
 
 	String[] names = new String[] {"My terminal 1", "My terminal 2"};
 	TerminalFactory factory = TerminalFactory.getInstance("CardTerminalSimulator", names);
@@ -162,16 +161,16 @@ Creating multiple terminals via the `TerminalFactory` API:
 	assertNotNull(cardTerminals.getTerminal("My terminal 1"));
 	assertNotNull(cardTerminals.getTerminal("My terminal 2"));
 
-**Current version's limitations:**  
+#### Current version's limitations
 
-- The `Card#openLogicalChannel` method is not supported.
-- The `Card#transmitControlCommand` method is not supported.
+- The `javax.smartcardio.Card#openLogicalChannel` method is not supported.
+- The `javax.smartcardio.Card#transmitControlCommand` method is not supported.
 
-**Legacy TerminalFactory**
+#### Legacy TerminalFactory
 
 Previous versions of jCardSim provided a limited `TerminalFactory` implementation (`JCSTerminal`). An example is provided in [JCardSimProviderTest.java](https://github.com/licel/jcardsim/blob/master/src/test/java/com/licel/jcardsim/smartcardio/JCardSimProviderTest.java).
 
-### Using the remote API
+### Using the `JavaCardRemoteInterface` interface
 
 It is possible to interact with a remote instance of jCardSim. For example you may
 run one or multiple instances of virtual Java Card and connect to it via TCP/IP.

--- a/sitedocs/quick_start_guide_using_in_cli_mode.md
+++ b/sitedocs/quick_start_guide_using_in_cli_mode.md
@@ -1,13 +1,11 @@
-### Downloading jCardSim
-Follow the link to download jCardSim jar archive:  
-[https://github.com/licel/jcardsim/raw/master/jcardsim-2.2.2-all.jar](https://github.com/licel/jcardsim/raw/master/jcardsim-2.2.2-all.jar)
+## Quick Start Guide: CLI
 
-### Starting jCardSim in a CLI mode
-To simplify the development and debugging process, jCardSim works directly with class files. You do not need to convert your Java Card applet to CAP in order to use it in the simulator.
+jCardSim includes two classes which run an instance of the simulator directly from the command line:
 
-The simulator has a CLI and an API, so you can choose what you want to use. See more about using API and unit testing in the second part of
-the [Quick Start Guide](http://jcardsim.org/docs/quick-start-guide-simulator-api).
-For sending APDUs via APDU scripts you should use the class `com.licel.jcardsim.utils.APDUScriptTool`.
+ - `APDUScriptTool` reads command APDUs from a file and writes the response APDUs
+ - `BixVReaderCard` connects to a PC/SC virtual reader
+
+### Using `APDUScriptTool`
 
 **Start parameters:**
 
@@ -20,7 +18,9 @@ For sending APDUs via APDU scripts you should use the class `com.licel.jcardsim.
 	com.licel.jcardsim.card.applet.{index}.Class=<Applet ClassName>
 
 where *{index}* is a number from 0 to 10.
->**NOTE:** Applet classes and it's dependencies must be in class path when simulator starts.
+
+To simplify the development and debugging process, jCardSim works directly with class files. You do not need to convert your Java Card applet to CAP in order to use it in the simulator.
+**NOTE:** Applet classes and their dependencies must be in the class path when the simulator starts.
 
 An example settings file:
 
@@ -29,7 +29,7 @@ An example settings file:
 
 `<apdu script>` - file with APDU commands in C-APDU format. This file is compatible with the script format of *apdutool* from the Java Card Development Kit.
 
-C-APDUs ends with `(;)` and comments begin with `//`
+C-APDUs ends with `;` and comments begin with `//`.
 
 APDU commands can be represented by DEC or HEX characters. HEX characters start with `0x`.
 One APDU command (C-APDU) can span multiple lines.
@@ -80,4 +80,6 @@ Now we save the C-APDU script into the file `helloworld.apdu` and start the simu
 
 The output matches the format used by *apdutool*.
 
-> The second part: [Quick Start Guide: Simulator API](http://jcardsim.org/docs/quick-start-guide-simulator-api).
+### Using `BixVReaderCard`
+
+See the blog post: [Work with jCardSim through PC/SC virtual reader](https://jcardsim.org/blogs/work-jcardsim-through-pcsc-virtual-reader)


### PR DESCRIPTION
This slightly simplifies the build process by locating the JCDK automatically from the environment, without requiring the user to create a local Maven settings file (`.m2/settings.xml`).

This also makes some adjustments to the jCardSim build instructions and quick start guides, so that they are easier to follow. It adds a reference to `BixVReader` which is currently not mentioned anywhere. Please update the documentation hosted on https://jcardsim.org/docs/ with these changes.