### PR TITLE
fixed RSAKeyPair generation issues

### DIFF
--- a/src/main/java/com/licel/jcardsim/crypto/ByteContainer.java
+++ b/src/main/java/com/licel/jcardsim/crypto/ByteContainer.java
@@ -106,7 +106,7 @@ public final class ByteContainer {
      * @param length length of data in byte array
      */
     public void setBytes(byte[] buff, short offset, short length) {
-        if (data == null) {
+        if (data == null || data.length < length) {
             switch (memoryType) {
                 case JCSystem.MEMORY_TYPE_TRANSIENT_DESELECT:
                     data = JCSystem.makeTransientByteArray(length, JCSystem.CLEAR_ON_DESELECT);
@@ -183,5 +183,12 @@ public final class ByteContainer {
      */
     public boolean isInitialized() {
         return length > 0;
+    }
+
+    /**
+     * Sets the <code>data</code> field to <code>null</code>
+     */
+    void clearData() {
+        this.data = null;
     }
 }


### PR DESCRIPTION
ByteContainer: added check for data field length because in some cases it caused tests failure.
KeyPairImpl: added length check for generated RSA pair components. If it differs from required keyLength then clean current privateKey and publicKey exponent and modulus data, because its last bytes can affect generated key values.