### PR TITLE
fix bytecode errors, -noverify not needed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm-all</artifactId>
-            <version>5.0.3</version>
+            <version>5.2</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
- fixes stackmap frame errors in the generated bytecode
- removes errors like "Expecting a stackmap frame at branch target 19"
- deprecared remapper removed
- works for JDK 8, higher versions do not support 1.5 version set as the pom target