### PR TITLE
Add basic support for connecting to vsmartcard/vpcd

### DIFF
--- a/src/main/java/com/licel/jcardsim/remote/VSmartCard.java
+++ b/src/main/java/com/licel/jcardsim/remote/VSmartCard.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2018 Joyent, Inc
+ * Copyright 2020 The University of Queensland
+ * Copyright 2013 Licel LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.licel.jcardsim.remote;
+
+import com.licel.jcardsim.base.CardManager;
+import com.licel.jcardsim.base.Simulator;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.security.InvalidParameterException;
+import java.util.Enumeration;
+import java.util.Properties;
+
+/**
+ * VSmartCard Card Implementation.
+ *
+ * @author alex@cooperi.net
+ */
+public class VSmartCard {
+
+    Simulator sim;
+
+    public VSmartCard(String host, int port) throws IOException {
+        VSmartCardTCPProtocol driverProtocol = new VSmartCardTCPProtocol();
+        driverProtocol.connect(host, port);
+        startThread(driverProtocol);
+    }
+
+    static public void main(String args[]) throws Exception {
+        if (args.length !=1) {
+            System.out.println("Usage: java com.licel.jcardsim.remote.VSmartCard <jcardsim.cfg>");
+            System.exit(-1);
+        }
+        Properties cfg = new Properties();
+        // init Simulator
+        FileInputStream fis = null;
+        try {
+            fis = new FileInputStream(args[0]);
+            cfg.load(fis);
+        } catch (Throwable t) {
+            System.err.println("Unable to load configuration " + args[0] + " due to: " + t.getMessage());
+            System.exit(-1);
+        } finally {
+            if (fis != null) {
+                fis.close();
+            }
+        }
+        final Enumeration<?> keys = cfg.propertyNames();
+        while (keys.hasMoreElements()) {
+            String propertyName = (String) keys.nextElement();
+            System.setProperty(propertyName, cfg.getProperty(propertyName));
+        }
+
+        String propKey = "com.licel.jcardsim.vsmartcard.host";
+        String host = System.getProperty(propKey);
+        if (host == null) {
+            throw new InvalidParameterException("Missing value for property: " + propKey);
+        }
+
+        propKey = "com.licel.jcardsim.vsmartcard.port";
+        String port = System.getProperty(propKey);
+        if (port == null) {
+            throw new InvalidParameterException("Missing value for property: " + propKey);
+        }
+
+        new VSmartCard(host, Integer.parseInt(port));
+    }
+
+    private void startThread(VSmartCardTCPProtocol driverProtocol) throws IOException {
+        sim = new Simulator();
+        final IOThread ioThread = new IOThread(sim, driverProtocol);
+        ShutDownHook hook = new ShutDownHook(ioThread);
+        Runtime.getRuntime().addShutdownHook(hook);
+        ioThread.start();
+    }
+
+    static class ShutDownHook extends Thread {
+        IOThread ioThread;
+
+        public ShutDownHook(IOThread ioThread) {
+            this.ioThread = ioThread;
+        }
+
+        public void run() {
+            ioThread.isRunning = false;
+            System.out.println("Shutdown connections");
+            ioThread.driverProtocol.disconnect();
+        }
+    }
+
+    static class IOThread extends Thread {
+        VSmartCardTCPProtocol driverProtocol;
+        Simulator sim;
+        boolean isRunning;
+
+        public IOThread(Simulator sim, VSmartCardTCPProtocol driverProtocol) {
+            this.sim = sim;
+            this.driverProtocol = driverProtocol;
+            isRunning = true;
+        }
+
+        @Override
+        public void run() {
+            while (isRunning) {
+                try {
+                    int cmd = driverProtocol.readCommand();
+                    switch (cmd) {
+                        case VSmartCardTCPProtocol.POWER_ON:
+                        case VSmartCardTCPProtocol.RESET:
+                            sim.reset();
+                            break;
+                        case VSmartCardTCPProtocol.GET_ATR:
+                            driverProtocol.writeData(sim.getATR());
+                            break;
+                        case VSmartCardTCPProtocol.APDU:
+                            final byte[] apdu = driverProtocol.readData();
+                            final byte[] reply = CardManager.dispatchApdu(sim, apdu);
+                            driverProtocol.writeData(reply);
+                            break;
+                    }
+                } catch (Exception e) {}
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/licel/jcardsim/remote/VSmartCardTCPProtocol.java
+++ b/src/main/java/com/licel/jcardsim/remote/VSmartCardTCPProtocol.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2018 Joyent, Inc
+ * Copyright 2020 The University of Queensland
+ * Copyright 2017 Licel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+package com.licel.jcardsim.remote;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import java.net.Socket;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * VSmartCard TCP protocol implementation. Used by VSmartCard.
+ *
+ * @author alex@cooperi.net
+ */
+public class VSmartCardTCPProtocol {
+    private Socket socket;
+    private InputStream  dataInput;
+    private OutputStream dataOutput;
+    private int frameLen = -1;
+
+    public static final int POWER_OFF = 0;
+    public static final int POWER_ON = 1;
+    public static final int RESET = 2;
+    public static final int GET_ATR = 4;
+    public static final int APDU = -1;
+
+    public void connect(String host, int port) throws IOException {
+        socket = new Socket(host, port);
+
+        try {
+            TimeUnit.SECONDS.sleep(3);
+        } catch (InterruptedException ignore) {}
+
+        dataInput   = socket.getInputStream();
+        dataOutput  = socket.getOutputStream();
+    }
+
+    public void disconnect() {
+        closeSocket(socket);
+    }
+
+    public int readCommand() throws IOException {
+        final byte[] cmdBuf = new byte[3];
+        read(cmdBuf, 0, 2, dataInput);
+        final int len = ((cmdBuf[0] << 8) & 0xFF00) | (cmdBuf[1] & 0xFF);
+        if (len == 1) {
+            read(cmdBuf, 2, 1, dataInput);
+            final int cmd = cmdBuf[2];
+            return (cmd);
+        }
+        frameLen = len;
+        return (APDU);
+    }
+
+    public byte[] readData() throws IOException {
+        if (frameLen == -1) {
+            throw new IOException("No APDU command waiting");
+        }
+        final byte[] buf = new byte[frameLen];
+        read(buf, dataInput);
+        frameLen = -1;
+        return buf;
+    }
+
+    public void writeData(byte[] data) throws IOException {
+        final byte[] buf = new byte[2 + data.length];
+        buf[0] = (byte)(((data.length & 0xFF00) >> 8) & 0xFF);
+        buf[1] = (byte)(data.length & 0xFF);
+        System.arraycopy(data, 0, buf, 2, data.length);
+        dataOutput.write(buf);
+    }
+
+    private void closeSocket(Socket sock) {
+        try {
+            sock.close();
+        } catch (IOException ignored) {}
+    }
+
+    private void read(byte[] buf, InputStream stream) throws IOException {
+        read(buf, 0, buf.length, stream);
+    }
+
+    private void read(byte[] buf, int offset, int len, InputStream stream) throws IOException {
+        while (len > 0) {
+            final int retval = stream.read(buf, offset, len);
+
+            if (retval < 0) {
+                throw new IOException("Got negative number from socket");
+            }
+
+            len    -= retval;
+            offset += retval;
+        }
+    }
+}


### PR DESCRIPTION
This implements the basic operations (power on, reset, get ATR and exchange APDU) for the vsmartcard/vpcd protocol (see [frankmorgner's page](https://frankmorgner.github.io/vsmartcard/virtualsmartcard/README.html)). It's very similar to the BixVReaderCard but with 16-bit opcodes. vpcd/vsmartcard is available on Linux and other platforms as well as Windows, which makes this a bit more convenient to use in e.g. a CI/CD setting for automatic testing or similar.

Like the BixVReaderCard code, you use this by running with `VSmartCard` as the main class, and give a single argument: the path to a properties file. In the properties files, you need to add `com.licel.jcardsim.vsmartcard.host` and `com.licel.jcardsim.vsmartcard.port` so that it knows what to connect to (it gives appropriate error messages if they're missing).

I put this together a few years ago for testing [PivApplet](https://github.com/arekinath/pivapplet) and have been using it there pretty regularly (combined with a few other patches to fix up some crypto issues it runs into).