### PR TITLE
Add option to randomize RandomData

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ jCardSim (Official repo of the [jCardSim](http://jcardsim.org) project)
 
 ![alt text](https://licelus.com/wp-content/uploads/DCA2013_Badge_Winner.jpg "jCardSim is a winner of Duke's Choice 2013")
 
+This is a forked repo with additional fixes, e.g., POM file fixes, `-noverify` not needed / bytecode generation fixes, 
+java 9+ compilation fixes.
+
 jCardSim is an open source simulator for Java Card, v.2.2/3.0.5:
 
 * `javacard.framework.*`
@@ -47,13 +50,19 @@ assertEquals(0x9000, response.getSW());
 
 *Latest stable release 2.2.2*: https://github.com/licel/jcardsim/raw/master/jcardsim-2.2.2-all.jar
 
+## Maven
 *Maven Central Repository*
 ```xml
 <dependency>
   <groupId>com.klinec</groupId>
   <artifactId>jcardsim</artifactId>
-  <version>3.5.0.4</version>
+  <version>3.5.0.9</version>
 </dependency>
+```
+
+Gradle:
+```groovy
+compile('com.klinec:jcardsim:3.0.5.9')
 ```
 
 ### What is the difference from Oracle Java Card Development Kit simulator?

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ assertEquals(0x9000, response.getSW());
 <dependency>
   <groupId>com.klinec</groupId>
   <artifactId>jcardsim</artifactId>
-  <version>3.5.0.9</version>
+  <version>3.0.5.9</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ jCardSim (Official repo of the [jCardSim](http://jcardsim.org) project)
 
 ![alt text](https://licelus.com/wp-content/uploads/DCA2013_Badge_Winner.jpg "jCardSim is a winner of Duke's Choice 2013")
 
-**Please note** that we moved our code repository from Google Code to GitHub.
-
 jCardSim is an open source simulator for Java Card, v.2.2/3.0.5:
 
 * `javacard.framework.*`
@@ -50,16 +48,9 @@ assertEquals(0x9000, response.getSW());
 *Maven Central Repository*
 ```xml
 <dependency>
-  <groupId>com.licel</groupId>
+  <groupId>com.klinec</groupId>
   <artifactId>jcardsim</artifactId>
-  <version>2.2.1</version>
-</dependency>
-```
-```xml
-<dependency>
-  <groupId>com.licel</groupId>
-  <artifactId>jcardsim</artifactId>
-  <version>2.2.2</version>
+  <version>3.5.0.4</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.klinec</groupId>
-    <version>3.0.5.4</version>
+    <version>3.0.5.5</version>
     <packaging>jar</packaging>
     <url>http://maven.apache.org</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.klinec</groupId>
-    <version>3.0.5.5</version>
+    <version>3.0.5.6</version>
     <packaging>jar</packaging>
     <url>http://maven.apache.org</url>
 
@@ -224,14 +224,14 @@
                     </execution>
                 </executions>
             </plugin>
-	    <plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-        	<artifactId>maven-surefire-plugin</artifactId>
+                <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.19.1</version>
-		<configuration>
-		    <argLine>-noverify</argLine>
-		</configuration>
-	    </plugin>                                      
+                <configuration>
+                    <argLine>-noverify</argLine>
+                </configuration>
+            </plugin>
             <!-- patch -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -239,18 +239,33 @@
                 <version>1.4.0</version>
                 <executions>
                     <execution>
+                        <id>cardApi</id>
                         <phase>process-classes</phase>
                         <goals>
                             <goal>java</goal>
                         </goals>
+                        <configuration>
+                            <mainClass>com.licel.jcardsim.utils.JavaCardApiProcessor</mainClass>
+                            <arguments>
+                                <argument>${project.build.directory}/classes</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>pom</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <mainClass>com.licel.jcardsim.utils.PomProcessor</mainClass>
+                            <arguments>
+                                <argument>${project.build.directory}</argument>
+                            </arguments>
+                        </configuration>
                     </execution>
                 </executions>
-                <configuration>
-                    <mainClass>com.licel.jcardsim.utils.JavaCardApiProcessor</mainClass>  
-                    <arguments>
-                        <argument>${project.build.directory}/classes</argument>
-                    </arguments>
-                </configuration>
+
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -269,6 +284,7 @@
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>1.7</version>
                 <configuration>
+                    <keepDependenciesWithProvidedScope>false</keepDependenciesWithProvidedScope>
                     <minimizeJar>true</minimizeJar>
                     <relocations>
                         <relocation>
@@ -280,6 +296,12 @@
                         <includes>
                             <include>org.bouncycastle:*</include>
                         </includes>
+                        <excludes>
+                            <exclude>oracle.javacard:*</exclude>
+                            <exclude>oracle.javacard:*:*:*</exclude>
+                            <exclude>*:api_classic</exclude>
+                            <exclude>oracle.javacard:api_classic</exclude>
+                        </excludes>
                     </artifactSet>
                     <filters>
                         <filter>
@@ -300,11 +322,18 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <keepDependenciesWithProvidedScope>false</keepDependenciesWithProvidedScope>
                             <minimizeJar>true</minimizeJar>
                             <artifactSet>
                                 <includes>
                                     <include>org.bouncycastle:*</include>
                                 </includes>
+                                <excludes>
+                                    <exclude>oracle.javacard:*</exclude>
+                                    <exclude>oracle.javacard:*:*:*</exclude>
+                                    <exclude>*:api_classic</exclude>
+                                    <exclude>oracle.javacard:api_classic</exclude>
+                                </excludes>
                             </artifactSet>
                             <filters>
                                 <filter>
@@ -325,10 +354,17 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <keepDependenciesWithProvidedScope>false</keepDependenciesWithProvidedScope>
                             <artifactSet>
                                 <includes>
                                     <include>org.bouncycastle:*</include>
                                 </includes>
+                                <excludes>
+                                    <exclude>oracle.javacard:*</exclude>
+                                    <exclude>oracle.javacard:*:*:*</exclude>
+                                    <exclude>*:api_classic</exclude>
+                                    <exclude>oracle.javacard:api_classic</exclude>
+                                </excludes>
                             </artifactSet>
                             <minimizeJar>true</minimizeJar>
                             <shadedArtifactAttached>true</shadedArtifactAttached>
@@ -418,7 +454,7 @@
 
                                 <echo>Testing shaded JAR: ${project.artifactId}-${project.version}-android.jar</echo>
                                 <junit fork="yes" forkmode="once" haltonfailure="yes" printsummary="true">
-				    <jvmarg value="-noverify"/>
+				                    <jvmarg value="-noverify"/>
                                     <classpath>
                                         <path refid="testClasspath" />
                                         <pathelement location="${ant.build.dir}/bin" />

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.klinec</groupId>
-    <version>3.0.5.6</version>
+    <version>3.0.5.7</version>
     <packaging>jar</packaging>
     <url>http://maven.apache.org</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.klinec</groupId>
-    <version>3.0.5.7</version>
+    <version>3.0.5.8</version>
     <packaging>jar</packaging>
     <url>http://maven.apache.org</url>
 
@@ -159,10 +159,30 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.ow2.asm</groupId>-->
+<!--            <artifactId>asm-all</artifactId>-->
+<!--            <version>5.2</version>-->
+<!--        </dependency>-->
         <dependency>
             <groupId>org.ow2.asm</groupId>
-            <artifactId>asm-all</artifactId>
-            <version>5.0.4</version>
+            <artifactId>asm-commons</artifactId>
+            <version>7.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-tree</artifactId>
+            <version>7.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-util</artifactId>
+            <version>7.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-analysis</artifactId>
+            <version>7.2</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,8 +2,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.licel</groupId>
-    <version>3.0.5-SNAPSHOT</version>
+    <groupId>com.klinec</groupId>
+    <version>3.0.5.4</version>
     <packaging>jar</packaging>
     <url>http://maven.apache.org</url>
 
@@ -41,31 +41,58 @@
         <java.version>1.5</java.version>
         <jcApiVersion>3.0.5</jcApiVersion>
     </properties>
-    
+
+    <!-- Maven distribution repositories -->
     <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
         <repository>
-            <id>bintray-jcardsim-maven-jCardSim</id>
-            <name>jcardsim-maven-jCardSim</name>
-            <url>https://api.bintray.com/maven/jcardsim/maven/jCardSim</url>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>    
 
     <scm>
-        <connection>scm:git:git@github.com:licel/jcardsim.git</connection>
-        <developerConnection>scm:git:git@github.com:licel/jcardsim.git</developerConnection>
-        <url>git@github.com:licel/jcardsim.git</url>
+        <connection>scm:git:git@github.com:ph4r05/jcardsim.git</connection>
+        <developerConnection>scm:git:git@github.com:ph4r05/jcardsim.git</developerConnection>
+        <url>git@github.com:ph4r05/jcardsim.git</url>
     </scm>
-    
+
+    <!-- Releasing: http://central.sonatype.org/pages/apache-maven.html -->
     <profiles>
         <profile>
-            <id>sign</id>
-            <activation>
-                <property>
-                    <name>keystoreLocation</name>
-                </property>
-            </activation>
+            <id>release</id>
             <build>
                 <plugins>
+
+                    <!-- Release -->
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.3</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-release-plugin</artifactId>
+                        <version>2.5</version>
+                        <configuration>
+                            <autoVersionSubmodules>true</autoVersionSubmodules>
+                            <useReleaseProfile>false</useReleaseProfile>
+                            <releaseProfiles>release</releaseProfiles>
+                            <goals>deploy</goals>
+                        </configuration>
+                    </plugin>
+
+                    <!-- Sources & Javadocs -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
@@ -73,51 +100,44 @@
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
-                                <phase>verify</phase>
                                 <goals>
                                     <goal>jar-no-fork</goal>
                                 </goals>
                             </execution>
                         </executions>
-                    </plugin>                    
+                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>${maven-javadoc-plugin.version}</version>
-                        <configuration>
-                            <author>false</author>
-                            <bottom>&nbsp;</bottom>
-                        </configuration>    
-                    </plugin>            
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-jarsigner-plugin</artifactId>
-                        <version>1.2</version>
+                        <version>2.9.1</version>
                         <executions>
                             <execution>
-                                <id>sign</id>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- GPG signature -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.5</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
                             </execution>
-                            <execution>
-                                <id>verify</id>
-                                <goals>
-                                    <goal>verify</goal>
-                                </goals>
-                            </execution>
                         </executions>
-                        <configuration>
-                            <keystore>${keystoreLocation}</keystore>
-                            <alias>${keyAlias}</alias>
-                            <storepass>${keystorePass}</storepass>
-                            <keypass>${keyPass}</keypass>
-                            <storetype>${storeType}</storetype>
-                        </configuration>
-                    </plugin>                
+                    </plugin>
                 </plugins>
             </build>
-        </profile> 
+        </profile>
     </profiles>
   
     <dependencies>
@@ -136,7 +156,8 @@
             <groupId>oracle.javacard</groupId>
             <artifactId>api_classic</artifactId>
             <version>${jcApiVersion}</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.ow2.asm</groupId>
@@ -206,7 +227,7 @@
 	    <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
         	<artifactId>maven-surefire-plugin</artifactId>
-                <version>2.21.0</version>
+                <version>2.19.1</version>
 		<configuration>
 		    <argLine>-noverify</argLine>
 		</configuration>
@@ -358,7 +379,7 @@
                         <configuration>
                             <target>
                                 <path id="compileClasspath">
-                                    <file name="${project.build.directory}/jcardsim-${project.version}.jar" />
+                                    <file name="${project.build.directory}/${project.artifactId}-${project.version}.jar" />
                                     <file name="${user.home}/.m2/repository/junit/junit/${junit.version}/junit-${junit.version}.jar" />
                                 </path>
 
@@ -368,7 +389,7 @@
                                 <mkdir dir="${ant.build.dir}/reports"/>
                                 <mkdir dir="${ant.build.dir}/bin/unpacked"/>
                                 <!-- remove sign -->
-                                <unzip src="${project.build.directory}/jcardsim-${project.version}-android.jar"
+                                <unzip src="${project.build.directory}/${project.artifactId}-${project.version}-android.jar"
                                         dest="${ant.build.dir}/bin/unpacked">
                                     <patternset>
                                         <exclude name="**/*.SF"/>
@@ -395,7 +416,7 @@
                                     <fileset dir="${project.basedir}/src/test/resources" />
                                 </copy>
 
-                                <echo>Testing shaded JAR: jcardsim-${project.version}-android.jar</echo>
+                                <echo>Testing shaded JAR: ${project.artifactId}-${project.version}-android.jar</echo>
                                 <junit fork="yes" forkmode="once" haltonfailure="yes" printsummary="true">
 				    <jvmarg value="-noverify"/>
                                     <classpath>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <maven-javadoc-plugin.version>2.10.1</maven-javadoc-plugin.version>
         <ant.build.dir>${project.build.directory}/antrun/build</ant.build.dir>
         <junit.version>3.8.1</junit.version>
-        <java.version>1.5</java.version>
+        <java.version>1.7</java.version>
         <jcApiVersion>3.0.5</jcApiVersion>
     </properties>
 
@@ -162,7 +162,7 @@
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm-all</artifactId>
-            <version>5.0.3</version>
+            <version>5.0.4</version>
         </dependency>
     </dependencies>
 
@@ -218,6 +218,7 @@
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${project.build.directory}/classes</outputDirectory>
                                     <includes>**/*.class</includes>
+                                    <excludes>**/java/**/*.class</excludes>
                                 </artifactItem>
                             </artifactItems>                                    
                         </configuration>
@@ -273,10 +274,11 @@
                 <version>${maven-javadoc-plugin.version}</version>
                 <configuration>
                     <links>
-                        <link>http://docs.oracle.com/javase/7/docs/api/</link>
-                        <link>http://docs.oracle.com/javase/7/docs/jre/api/security/smartcardio/spec/</link>
+                        <link>https://docs.oracle.com/javase/7/docs/api/</link>
+                        <link>https://docs.oracle.com/javase/7/docs/jre/api/security/smartcardio/spec/</link>
                     </links>
                     <author>false</author>
+                    <source>7</source>
                 </configuration>
             </plugin>
             <plugin>
@@ -297,6 +299,9 @@
                             <include>org.bouncycastle:*</include>
                         </includes>
                         <excludes>
+                            <exclude>java.io:*</exclude>
+                            <exclude>java.lang:*</exclude>
+                            <exclude>java.rmi:*</exclude>
                             <exclude>oracle.javacard:*</exclude>
                             <exclude>oracle.javacard:*:*:*</exclude>
                             <exclude>*:api_classic</exclude>
@@ -329,6 +334,9 @@
                                     <include>org.bouncycastle:*</include>
                                 </includes>
                                 <excludes>
+                                    <exclude>java.io:*</exclude>
+                                    <exclude>java.lang:*</exclude>
+                                    <exclude>java.rmi:*</exclude>
                                     <exclude>oracle.javacard:*</exclude>
                                     <exclude>oracle.javacard:*:*:*</exclude>
                                     <exclude>*:api_classic</exclude>
@@ -396,13 +404,13 @@
                 <artifactId>maven-antrun-plugin</artifactId>
                 <version>1.8</version>
                 <dependencies>
-                    <dependency>
-                        <groupId>com.sun</groupId>
-                        <artifactId>tools</artifactId>
-                        <version>1.5.0</version>
-                        <scope>system</scope>
-                        <systemPath>${java.home}/../lib/tools.jar</systemPath>
-                    </dependency>
+<!--                    <dependency>-->
+<!--                        <groupId>com.sun</groupId>-->
+<!--                        <artifactId>tools</artifactId>-->
+<!--                        <version>1.5.0</version>-->
+<!--                        <scope>system</scope>-->
+<!--                        <systemPath>${java.home}/../lib/tools.jar</systemPath>-->
+<!--                    </dependency>-->
                     <dependency>
                         <groupId>org.apache.ant</groupId>
                         <artifactId>ant-junit</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.klinec</groupId>
-    <version>3.0.5.8</version>
+    <version>3.0.5.9</version>
     <packaging>jar</packaging>
     <url>http://maven.apache.org</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -159,11 +159,6 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>org.ow2.asm</groupId>-->
-<!--            <artifactId>asm-all</artifactId>-->
-<!--            <version>5.2</version>-->
-<!--        </dependency>-->
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm-commons</artifactId>

--- a/src/main/java/com/licel/jcardsim/crypto/AsymmetricSignatureImpl.java
+++ b/src/main/java/com/licel/jcardsim/crypto/AsymmetricSignatureImpl.java
@@ -104,19 +104,19 @@ public class AsymmetricSignatureImpl extends Signature implements SignatureMessa
                 engine = new RSADigestSigner(new BouncyCastlePrecomputedOrDigestProxy(new RIPEMD160Digest()));
                 break;
             case ALG_ECDSA_SHA:
-                engine = new DSADigestSigner(new ECDSASigner(), new SHA1Digest());
+                engine = new DSADigestSigner(new ECDSASigner(), new BouncyCastlePrecomputedOrDigestProxy(new SHA1Digest()));
                 break;
             case ALG_ECDSA_SHA_224:
-                engine = new DSADigestSigner(new ECDSASigner(), new SHA224Digest());
+                engine = new DSADigestSigner(new ECDSASigner(), new BouncyCastlePrecomputedOrDigestProxy(new SHA224Digest()));
                 break;
             case ALG_ECDSA_SHA_256:
-                engine = new DSADigestSigner(new ECDSASigner(), new SHA256Digest());
+                engine = new DSADigestSigner(new ECDSASigner(), new BouncyCastlePrecomputedOrDigestProxy(new SHA256Digest()));
                 break;
             case ALG_ECDSA_SHA_384:
-                engine = new DSADigestSigner(new ECDSASigner(), new SHA384Digest());
+                engine = new DSADigestSigner(new ECDSASigner(), new BouncyCastlePrecomputedOrDigestProxy(new SHA384Digest()));
                 break;
             case ALG_ECDSA_SHA_512:
-                engine = new DSADigestSigner(new ECDSASigner(), new SHA512Digest());
+                engine = new DSADigestSigner(new ECDSASigner(), new BouncyCastlePrecomputedOrDigestProxy(new SHA512Digest()));
                 break;
         }
     }
@@ -299,15 +299,30 @@ public class AsymmetricSignatureImpl extends Signature implements SignatureMessa
         throw new UnsupportedOperationException("Not supported yet."); 
     }
 
+    protected boolean supportDsaSignerComputedHash(){
+        final String propSupported = System.getProperty("com.licel.jcardsim.sign.dsasigner.computedhash", "0");
+        return Integer.parseInt(propSupported) > 0;
+    }
+
+    protected boolean supportedComputedHashSigner(){
+        return (engine instanceof RSADigestSigner)
+                || (engine instanceof PSSSigner)
+                || (supportDsaSignerComputedHash() && engine instanceof DSADigestSigner);
+    }
+
+    protected String getDigestFromSigner(){
+        return (engine instanceof RSADigestSigner || engine instanceof DSADigestSigner) ? "digest" : "contentDigest";
+    }
+
     public short signPreComputedHash(byte[] hashBuff,
                             short hashOffset,
                             short hashLength,
                             byte[] sigBuff,
                             short sigOffset) throws CryptoException {
         try {
-            if((engine instanceof RSADigestSigner) ||  (engine instanceof PSSSigner) ) {
+            if(supportedComputedHashSigner()) {
                 // set precomputed hava value - BouncyCastle specific
-                 Field h = engine.getClass().getDeclaredField(engine instanceof RSADigestSigner ? "digest" : "contentDigest");
+                 Field h = engine.getClass().getDeclaredField(getDigestFromSigner());
                  h.setAccessible(true);
                  Object digestObject = h.get(engine);
                  digestObject.getClass().getMethod("setPrecomputedValue", new Class[]{byte[].class, int.class, int.class})
@@ -322,9 +337,9 @@ public class AsymmetricSignatureImpl extends Signature implements SignatureMessa
     
     public boolean verifyPreComputedHash(byte[] hashBuff, short hashOffset, short hashLength, byte[] sigBuff, short sigOffset, short sigLength) throws CryptoException {
         try {
-            if((engine instanceof RSADigestSigner) || (engine instanceof PSSSigner)) {
+            if(supportedComputedHashSigner()) {
                 // set precomputed hava value - BouncyCastle specific
-                 Field h = engine.getClass().getDeclaredField(engine instanceof RSADigestSigner ? "digest" : "contentDigest");
+                 Field h = engine.getClass().getDeclaredField(getDigestFromSigner());
                  h.setAccessible(true);
                  Object digestObject = h.get(engine);
                  digestObject.getClass().getMethod("setPrecomputedValue", new Class[]{byte[].class, int.class, int.class})

--- a/src/main/java/com/licel/jcardsim/crypto/AsymmetricSignatureImpl.java
+++ b/src/main/java/com/licel/jcardsim/crypto/AsymmetricSignatureImpl.java
@@ -299,15 +299,10 @@ public class AsymmetricSignatureImpl extends Signature implements SignatureMessa
         throw new UnsupportedOperationException("Not supported yet."); 
     }
 
-    protected boolean supportDsaSignerComputedHash(){
-        final String propSupported = System.getProperty("com.licel.jcardsim.sign.dsasigner.computedhash", "0");
-        return Integer.parseInt(propSupported) > 0;
-    }
-
     protected boolean supportedComputedHashSigner(){
         return (engine instanceof RSADigestSigner)
                 || (engine instanceof PSSSigner)
-                || (supportDsaSignerComputedHash() && engine instanceof DSADigestSigner);
+                || (engine instanceof DSADigestSigner);
     }
 
     protected String getDigestFromSigner(){

--- a/src/main/java/com/licel/jcardsim/crypto/RandomDataImpl.java
+++ b/src/main/java/com/licel/jcardsim/crypto/RandomDataImpl.java
@@ -21,6 +21,9 @@ import javacard.security.RandomData;
 import org.bouncycastle.crypto.digests.SHA1Digest;
 import org.bouncycastle.crypto.prng.DigestRandomGenerator;
 import org.bouncycastle.crypto.prng.RandomGenerator;
+import org.bouncycastle.util.encoders.Hex;
+
+import java.security.SecureRandom;
 
 /**
  * Implementation <code>RandomData</code> based
@@ -34,6 +37,18 @@ public class RandomDataImpl extends RandomData {
     public RandomDataImpl(byte algorithm) {
         this.algorithm = algorithm;
         this.engine = new DigestRandomGenerator(new SHA1Digest());
+
+        final String randomSeed = System.getProperty("com.licel.jcardsim.randomdata.seed");
+        final String doSecureRandom = System.getProperty("com.licel.jcardsim.randomdata.secure", "0");
+        if (randomSeed != null){
+            this.engine.addSeedMaterial(Hex.decode(randomSeed));
+        }
+        else if ("1".equals(doSecureRandom)){
+            byte[] seed = new byte[32];
+            SecureRandom randomGenerator = new SecureRandom();
+            randomGenerator.nextBytes(seed);
+            this.engine.addSeedMaterial(seed);
+        }
     }
 
     public void generateData(byte[] buffer, short offset, short length) throws CryptoException {

--- a/src/main/java/com/licel/jcardsim/utils/JavaCardApiProcessor.java
+++ b/src/main/java/com/licel/jcardsim/utils/JavaCardApiProcessor.java
@@ -78,13 +78,14 @@ public class JavaCardApiProcessor {
     public static void proxyClass(File buildDir, String proxyClassFile, String targetClassFile, boolean skipConstructor) throws IOException {
         File proxyFile = new File(buildDir, proxyClassFile.replace(".", File.separator) + ".class");
         FileInputStream fProxyClass = new FileInputStream(proxyFile);
-        FileInputStream fTargetClass = new FileInputStream(new File(buildDir, targetClassFile.replace(".", File.separator) + ".class"));
+        File file = new File(buildDir, targetClassFile.replace(".", File.separator) + ".class");
+        FileInputStream fTargetClass = new FileInputStream(file);
         ClassReader crProxy = new ClassReader(fProxyClass);
         ClassNode cnProxy = new ClassNode();
-        crProxy.accept(cnProxy, 0);
+        crProxy.accept(cnProxy, ClassReader.SKIP_FRAMES);// ClassReader.EXPAND_FRAMES);
         ClassReader crTarget = new ClassReader(fTargetClass);
         ClassNode cnTarget = new ClassNode();
-        crTarget.accept(cnTarget, 0);
+        crTarget.accept(cnTarget, ClassReader.EXPAND_FRAMES);
 
         ClassNode cnProxyRemapped = new ClassNode();
         HashMap<String, String> map = new HashMap();
@@ -101,7 +102,7 @@ public class JavaCardApiProcessor {
         cnTarget.accept(ma);
         fProxyClass.close();
         fTargetClass.close();
-        FileOutputStream fos = new FileOutputStream(new File(buildDir, targetClassFile.replace(".", File.separator) + ".class"));
+        FileOutputStream fos = new FileOutputStream(file);
         fos.write(cw.toByteArray());
         fos.close();
         // remove proxy class
@@ -113,7 +114,7 @@ public class JavaCardApiProcessor {
         FileInputStream fProxyClass = new FileInputStream(sourceFile);
         ClassReader crProxy = new ClassReader(fProxyClass);
         ClassNode cnProxy = new ClassNode();
-        crProxy.accept(cnProxy, 0);
+        crProxy.accept(cnProxy, ClassReader.SKIP_FRAMES);
 
         ClassWriter cw = new ClassWriter(0);
         map.put(cnProxy.name, targetClassName.replace(".", "/"));

--- a/src/main/java/com/licel/jcardsim/utils/PomProcessor.java
+++ b/src/main/java/com/licel/jcardsim/utils/PomProcessor.java
@@ -30,7 +30,7 @@ import javax.xml.transform.stream.StreamResult;
 import java.io.File;
 
 /**
- * Injects jCardSim’s code into Java Card Api Reference Classes
+ * Removes jcard api_classic from the dependencies in POM
  */
 public class PomProcessor {
 

--- a/src/main/java/com/licel/jcardsim/utils/PomProcessor.java
+++ b/src/main/java/com/licel/jcardsim/utils/PomProcessor.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2015 Licel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.licel.jcardsim.utils;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.File;
+
+/**
+ * Injects jCardSim’s code into Java Card Api Reference Classes
+ */
+public class PomProcessor {
+
+    public static void main(String[] args) throws Exception {
+        if (args.length == 0){
+            throw new IllegalArgumentException("Build directory is required");
+        }
+
+        File buildDir = new File(args[0]);
+        if (!buildDir.exists() || !buildDir.isDirectory()) {
+            throw new RuntimeException("Invalid directory: " + buildDir);
+        }
+
+        final File depPom = new File(buildDir, "dependency-reduced-pom.xml");
+        if (!depPom.exists()){
+            System.err.println("POM not found: " + depPom.getAbsolutePath());
+            return;
+        }
+
+        DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder dBuilder;
+
+        try {
+            dBuilder = dbFactory.newDocumentBuilder();
+            Document doc = dBuilder.parse(depPom);
+
+            deleteElement(doc);
+
+            //write the updated document to file or console
+            doc.getDocumentElement().normalize();
+            TransformerFactory transformerFactory = TransformerFactory.newInstance();
+            Transformer transformer = transformerFactory.newTransformer();
+            DOMSource source = new DOMSource(doc);
+            StreamResult result = new StreamResult(depPom);
+            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+            transformer.transform(source, result);
+            System.out.println("XML file updated successfully");
+
+        } catch(Exception e){
+            System.err.println(e.getMessage());
+            e.printStackTrace(System.err);
+        }
+    }
+
+    private static void deleteElement(Document doc) {
+        NodeList projects = doc.getElementsByTagName("project");
+        if (projects.getLength() < 1){
+            System.err.println("Invalid number of project elements");
+            return;
+        }
+        
+        final Node project = projects.item(0);
+        if (project.getNodeType() != Node.ELEMENT_NODE){
+            System.err.println("Invalid project node type");
+            return;
+        }
+
+        Element elProject = (Element) project;
+        final NodeList dependencies = elProject.getElementsByTagName("dependencies");
+        if (dependencies.getLength() < 1){
+            System.err.println("Invalid num of dependencies");
+            return;
+        }
+
+        boolean found = false;
+        int depIdx = 0;
+        for(depIdx = 0; depIdx < dependencies.getLength(); depIdx++){
+            if (dependencies.item(depIdx).getParentNode() == elProject){
+                found = true;
+                break;
+            }
+        }
+
+        if (!found){
+            System.err.println("Project.dependencies not found");
+            return;
+        }
+
+        final Node nDeps = dependencies.item(depIdx);
+        if (nDeps.getNodeType() != Node.ELEMENT_NODE){
+            System.err.println("Invalid dependencies node type");
+            return;
+        }
+
+        Element elDeps = (Element) nDeps;
+        final NodeList depsNodeList = elDeps.getElementsByTagName("dependency");
+        if (depsNodeList.getLength() < 1){
+            System.err.println("No deps found");
+            return;
+        }
+
+        for(int i=0; i < depsNodeList.getLength(); i++){
+            final Element elDep = (Element)depsNodeList.item(i);
+            final NodeList nArtifacts = elDep.getElementsByTagName("artifactId");
+            if (nArtifacts.getLength() == 0){
+                continue;
+            }
+
+            final Element elArtifact = (Element)nArtifacts.item(0);
+            final Node alChild = elArtifact.getFirstChild();
+            if (alChild.getNodeType() == Node.TEXT_NODE && alChild.getNodeValue().equalsIgnoreCase("api_classic")){
+                System.err.println("api_classic found in dependencies");
+                elDeps.removeChild(elDep);
+                return;
+            }
+        }
+    }
+}


### PR DESCRIPTION
 Add option to randomize RandomData seed:
    
- if the System property `com.licel.jcardsim.randomdata.seed` is set, the hex-decoded value of the property is added as a seed material to the RandomData on initialization
- else if the System property `com.licel.jcardsim.randomdata.secure` is set to `1`, the SecureRandom is used to generate 32 random bytes that are added as a seed material to the RandomData
- else the original behavior is preserved to be consistent with previous versions (some tests might rely on the fixed randomness)
- Addresses also the #139, I've chosen a bit different approach to #141 mainly to preserve backward compatibility as some users may rely on the fixed seed