### PR TITLE
maven-antrun-plugin should not depend on tools...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -392,13 +392,6 @@
                 <version>1.8</version>
                 <dependencies>
                     <dependency>
-                        <groupId>com.sun</groupId>
-                        <artifactId>tools</artifactId>
-                        <version>1.5.0</version>
-                        <scope>system</scope>
-                        <systemPath>${java.home}/../lib/tools.jar</systemPath>
-                    </dependency>
-                    <dependency>
                         <groupId>org.apache.ant</groupId>
                         <artifactId>ant-junit</artifactId>
                         <version>1.9.5</version>


### PR DESCRIPTION
...which under Java 11 don't exist any more

At least on Ubuntu 20.04 and using Java 11 building fails with:

```
[INFO] --- maven-antrun-plugin:1.8:run (default) @ jcardsim ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  6.930 s
[INFO] Finished at: 2020-05-29T10:17:24+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-antrun-plugin:1.8:run (default) on project jcardsim: Execution default of goal org.apache.maven.plugins:maven-antrun-plugin:1.8:run failed: Plugin org.apache.maven.plugins:maven-antrun-plugin:1.8 or one of its dependencies could not be resolved: Could not find artifact com.sun:tools:jar:1.5.0 at specified path /usr/lib/jvm/java-11-openjdk-amd64/../lib/tools.jar -> [Help 1]
```