### PR TITLE
Max case 4 command APDU size is 261

### DIFF
--- a/src/main/java/com/licel/jcardsim/framework/APDUProxy.java
+++ b/src/main/java/com/licel/jcardsim/framework/APDUProxy.java
@@ -31,7 +31,7 @@ import javacard.framework.Util;
  */
 public class APDUProxy {
     // buffer size
-    private static final short BUFFER_SIZE = 260;
+    private static final short BUFFER_SIZE = 261;
     // buffer size (extended APDU) + (CLA,INS,P1,P2,0,Lc_Hi,Lc_Low,CData,Le_Hi,Le_Lo)
     private static final int BUFFER_EXTENDED_SIZE = Short.MAX_VALUE + 10;
     // input block size, for T0 protocol = 1


### PR DESCRIPTION
As can be seen from this output, sending a valid max length APDU fails:
```
== APDU
0000:  00 46 00 00  FF 81 28 D3
0008:  5E 47 20 36  BC 4F B7 E1
0010:  3C 78 5E D2  01 E0 65 F9
0018:  8F CF A6 F6  F4 0D EF 4F
0020:  92 B9 EC 78  93 EC 28 FC
0028:  D4 12 B1 F1  B3 2E 27 82
0030:  28 3E E3 0B  56 8F BA B0
0038:  F8 83 CC EB  D4 6D 3F 3B
0040:  B8 A2 A7 35  13 F5 EB 79
0048:  DA 66 19 0E  B0 85 FF A9
0050:  F4 92 F3 75  A9 7D 86 0E
0058:  B4 83 28 52  08 83 94 9D
0060:  FD BC 42 D3  AD 19 86 40
0068:  68 8A 6F E1  3F 41 34 95
0070:  54 B4 9A CC  31 DC CD 88
0078:  45 39 81 6F  5E B4 AC 8F
0080:  B1 F1 A6 84  51 04 43 BD
0088:  7E 9A FB 53  D8 B8 52 89
0090:  BC C4 8E E5  BF E6 F2 01
0098:  37 D1 0A 08  7E B6 E7 87
00A0:  1E 2A 10 A5  99 C7 10 AF
00A8:  8D 0D 39 E2  06 11 14 FD
00B0:  D0 55 45 EC  1C C8 AB 40
00B8:  93 24 7F 77  27 5E 07 43
00C0:  FF ED 11 71  82 EA A9 C7
00C8:  78 77 AA AC  6A C7 D3 52
00D0:  45 D1 69 2E  8E E1 85 28
00D8:  D3 5E 47 20  36 BC 4F B7
00E0:  E1 3C 78 5E  D2 01 E0 65
00E8:  F9 8F CF A5  B6 8F 12 A3
00F0:  2D 48 2E C7  EE 86 58 E9
00F8:  86 91 55 5B  44 C5 93 11
0100:  87 02 00 01  00

java.lang.RuntimeException: Internal reflection error
    at com.licel.jcardsim.base.SimulatorRuntime.resetAPDU(SimulatorRuntime.java:426)
    at com.licel.jcardsim.base.SimulatorRuntime.transmitCommand(SimulatorRuntime.java:301)
    at com.licel.jcardsim.base.Simulator.transmitCommand(Simulator.java:260)
    at com.licel.jcardsim.base.CardManager.dispatchApduImpl(CardManager.java:66)
    at com.licel.jcardsim.base.CardManager.dispatchApdu(CardManager.java:36)
    at com.licel.jcardsim.remote.VSmartCard$IOThread.run(VSmartCard.java:158)
Caused by: java.lang.reflect.InvocationTargetException
    at jdk.internal.reflect.GeneratedMethodAccessor1.invoke(Unknown Source)
    at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.base/java.lang.reflect.Method.invoke(Method.java:566)
    at com.licel.jcardsim.base.SimulatorRuntime.resetAPDU(SimulatorRuntime.java:424)
    ... 5 more
Caused by: java.lang.ArrayIndexOutOfBoundsException: arraycopy: last destination index 261 out of bounds for byte[2
    at java.base/java.lang.System.arraycopy(Native Method)
    at javacard.framework.APDU.internalReset(Unknown Source)
    ... 9 more
```