### PR TITLE
Do not throw CryptoException if EC KeyBuilder.buildKey() does not match a known curve

### DIFF
--- a/src/main/java/com/licel/jcardsim/crypto/ECKeyImpl.java
+++ b/src/main/java/com/licel/jcardsim/crypto/ECKeyImpl.java
@@ -60,7 +60,11 @@ public abstract class ECKeyImpl extends KeyImpl implements ECKey {
     public ECKeyImpl(byte keyType, short keySize) {
         this.size = keySize;
         this.type = keyType;
-        setDomainParameters(getDefaultsDomainParameters(type, size));
+        try {
+            setDomainParameters(getDefaultsDomainParameters(type, size));
+        } catch (CryptoException e) {
+            clearKeyInternal();
+        }
     }
 
     /**
@@ -79,16 +83,21 @@ public abstract class ECKeyImpl extends KeyImpl implements ECKey {
         setDomainParameters(parameters.getParameters());
     }
 
-    public void clearKey() {
+    private void clearKeyInternal() {
         a.clear();
         b.clear();
         g.clear();
         r.clear();
         fp.clear();
         k = 0;
+        isKInitialized = false;
         e1 = 0;
         e2 = 0;
         e3 = 0;
+    }
+
+    public void clearKey() {
+        clearKeyInternal();
     }
 
     protected boolean isDomainParametersInitialized() {


### PR DESCRIPTION
The curve parameters can in any case be set later via the ECKeyImpl.setX().

This way one can for example use Brainpool curves with IsoApplet & OpenSC.

Before:
```
$ pkcs11-tool --login --pin 648219 --keypairgen --key-type EC:brainpoolP320r1 --label test_ec --id ec
Using slot 0 with a present token (0x0)
error: PKCS11 function C_GenerateKeyPair failed: rv = CKR_GENERAL_ERROR (0x5)
Aborting.
```
After:
```
$ pkcs11-tool --login --pin ****** --keypairgen --key-type EC:brainpoolP320r1 --label test_ec --id ec
Using slot 0 with a present token (0x0)
Key pair generated:
Private Key Object; EC
  label:      test_ec
  ID:         ec
  Usage:      sign, derive
Public Key Object; EC  EC_POINT 320 bits
  EC_POINT:   045104bd63ad7b54316824c09eaf02a890e64878d9650f0bb098fbadf2a8732de2ff9917afb0199dca09bb2d77c3297c2a81083e71bddc3c7e49ff9910ef5673f15b88a924bdb1ee8649dcbaaeff7540d08fd7
  EC_PARAMS:  06092b2403030208010109
  label:      test_ec
  ID:         ec
  Usage:      verify, derive
```