### PR TITLE
Support JCSystem.makeGlobalArray() call

### DIFF
--- a/src/main/java/com/licel/jcardsim/base/TransientMemory.java
+++ b/src/main/java/com/licel/jcardsim/base/TransientMemory.java
@@ -80,6 +80,36 @@ public class TransientMemory {
     }
 
     /**
+     * @see javacard.framework.JCSystem#makeGlobalArray(byte,short)
+     * @param type the array type - must be one of : ARRAY_TYPE_BOOLEAN, ARRAY_TYPE_BYTE, ARRAY_TYPE_SHORT, ARRAY_TYPE_INT, or ARRAY_TYPE_OBJECT
+     * @param length the length of the global transient array
+     * @return the new transient Object array
+     */
+    public Object makeGlobalArray(byte type, short length){
+        Object array = null;
+        switch (type){
+            case JCSystem.ARRAY_TYPE_BOOLEAN:
+                array = makeBooleanArray(length, JCSystem.CLEAR_ON_RESET);
+                break;
+            case JCSystem.ARRAY_TYPE_BYTE:
+                array = makeByteArray(length, JCSystem.CLEAR_ON_RESET);
+                break;
+            case JCSystem.ARRAY_TYPE_SHORT:
+                array = makeShortArray(length, JCSystem.CLEAR_ON_RESET);
+                break;
+            case JCSystem.ARRAY_TYPE_OBJECT:
+                array = makeObjectArray(length, JCSystem.CLEAR_ON_RESET);
+                break;
+            case JCSystem.ARRAY_TYPE_INT:
+            default:
+                SystemException.throwIt(SystemException.ILLEGAL_VALUE);
+                break;
+        }
+
+        return array;
+    }
+
+    /**
      * @see javacard.framework.JCSystem#isTransient(Object)
      * @param theObj the object being queried
      * @return <code>NOT_A_TRANSIENT_OBJECT</code>, <code>CLEAR_ON_RESET</code>, or <code>CLEAR_ON_DESELECT</code>

--- a/src/main/java/com/licel/jcardsim/framework/JCSystemProxy.java
+++ b/src/main/java/com/licel/jcardsim/framework/JCSystemProxy.java
@@ -140,6 +140,25 @@ public class JCSystemProxy {
     }
 
     /**
+     * Creates a global <code>CLEAR_ON_RESET</code> transient array of the type specified, with the specified array length.
+     * A global array can be accessed from any applet context.
+     * References to global arrays cannot be stored in class variables or instance variables or array components.
+     * (See Runtime Environment Specification, Java Card Platform, Classic Edition, section 6.2.2 for details)
+     * @param type the array type - must be one of : ARRAY_TYPE_BOOLEAN, ARRAY_TYPE_BYTE, ARRAY_TYPE_SHORT, ARRAY_TYPE_INT, or ARRAY_TYPE_OBJECT
+     * @param length the length of the global transient array
+     * @return the new transient Object array
+     * @throws NegativeArraySizeException if the <CODE>length</CODE> parameter is negative
+     * @throws SystemException with the following reason codes:
+     * <ul>
+     * <li><code>SystemException.ILLEGAL_VALUE</code> if type is not a valid type code. An implementation which does not support the "int" type may throw this exception if type is ARRAY_TYPE_INT
+     * <li><code>SystemException.NO_TRANSIENT_SPACE</code> if sufficient transient space is not available.
+     * </ul>
+     */
+    public static Object makeGlobalArray(byte type, short length){
+        return SimulatorSystem.instance().getTransientMemory().makeGlobalArray(type,length);
+    }
+
+    /**
      * Returns the current major and minor version of the Java Card API.
      * @return version number as byte.byte (major.minor)
      */

--- a/src/main/java/com/licel/jcardsim/samples/GlobalArrayAccess.java
+++ b/src/main/java/com/licel/jcardsim/samples/GlobalArrayAccess.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 Licel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.licel.jcardsim.samples;
+import javacard.framework.Shareable;
+/**
+ * Grants access to the global array.
+ *
+ */
+public interface GlobalArrayAccess extends Shareable{
+    public Object getGlobalArrayRef();
+}

--- a/src/main/java/com/licel/jcardsim/samples/GlobalArrayClientApplet.java
+++ b/src/main/java/com/licel/jcardsim/samples/GlobalArrayClientApplet.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2022 Licel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.licel.jcardsim.samples;
+
+import com.licel.jcardsim.utils.AIDUtil;
+
+import javacard.framework.*;
+
+/**
+ * Global array client applet.
+ *
+ * <p>Supported APDUs:</p>
+ *
+ * <ul>
+ *     <li><code>CLA=0x10 INS=1</code> Read global byte array with size from <code>Le</code></li>
+ *     <li><code>CLA=0x10 INS=2</code> Write global byte array value from <code>CData</code></li>
+ * </ul>
+ */
+public class GlobalArrayClientApplet extends BaseApplet{
+    private final static byte CLA = 0x10;
+    private final static byte INS_READ_GLOBAL_ARRAY_BYTE = 0x01;
+    private final static byte INS_WRITE_GLOBAL_ARRAY_BYTE = 0x02;
+
+    private static final short MAX_ALLOWED_GLOBAL_ARRAY_SIZE_BYTES = 64;
+
+    private AID serverAppletAID;
+
+    /**
+     * This method is called once during applet instantiation process.
+     * @param bArray the array containing installation parameters
+     * @param bOffset the starting offset in bArray
+     * @param bLength the length in bytes of the parameter data in bArray
+     * @throws ISOException if the install method failed
+     */
+    public static void install(byte[] bArray, short bOffset, byte bLength)
+            throws ISOException {
+        new GlobalArrayClientApplet(bArray,bOffset,bLength);
+    }
+
+    protected GlobalArrayClientApplet(byte[] bArray, short bOffset, byte bLength){
+        byte aidLen = bArray[bOffset];
+        byte[] aidBytes = new byte[aidLen];
+        Util.arrayCopyNonAtomic(bArray, (short) (bOffset+1), aidBytes, (short) 0, aidLen);
+
+        serverAppletAID = AIDUtil.create(aidBytes);
+
+        register();
+    }
+
+
+    public void process(APDU apdu) {
+        if(selectingApplet())
+            return;
+
+        byte[] buffer = apdu.getBuffer();
+
+        if( buffer[ISO7816.OFFSET_CLA] != CLA)
+            ISOException.throwIt(ISO7816.SW_CLA_NOT_SUPPORTED);
+
+        switch(buffer[ISO7816.OFFSET_INS]){
+            case INS_READ_GLOBAL_ARRAY_BYTE:
+                readGlobalArrayByte(apdu);
+                return;
+
+            case INS_WRITE_GLOBAL_ARRAY_BYTE:
+                writeGlobalArrayByte(apdu);
+                return;
+
+            default:
+                ISOException.throwIt(ISO7816.SW_INS_NOT_SUPPORTED);
+        }
+    }
+    
+    private void readGlobalArrayByte(APDU apdu){
+        GlobalArrayAccess shared = (GlobalArrayAccess)JCSystem.getAppletShareableInterfaceObject(serverAppletAID, (byte) 0);
+        byte[] globalArrayByte = (byte[]) shared.getGlobalArrayRef();
+
+        short le = apdu.setOutgoing();
+        apdu.setOutgoingLength(le);
+        apdu.sendBytesLong(globalArrayByte, (short) 0, le);
+    }
+
+    private void writeGlobalArrayByte(APDU apdu){
+        byte[] buffer = apdu.getBuffer();
+        byte numBytes = buffer[ISO7816.OFFSET_LC];
+        if( (numBytes > MAX_ALLOWED_GLOBAL_ARRAY_SIZE_BYTES) || (numBytes == 0) ){
+            ISOException.throwIt(ISO7816.SW_WRONG_LENGTH);
+        }
+
+        GlobalArrayAccess shared = (GlobalArrayAccess)JCSystem.getAppletShareableInterfaceObject(serverAppletAID, (byte) 0);
+        byte[] globalArrayByte = (byte[]) shared.getGlobalArrayRef();
+
+        byte bytesRead = (byte)apdu.setIncomingAndReceive();
+        byte bufferOffset = 0;
+
+        while(bytesRead >0){
+            Util.arrayCopyNonAtomic(buffer, ISO7816.OFFSET_CDATA, globalArrayByte, bufferOffset, bytesRead);
+            bufferOffset += bytesRead;
+            bytesRead = (byte)apdu.receiveBytes(ISO7816.OFFSET_CDATA);
+        }
+    }
+
+}

--- a/src/main/java/com/licel/jcardsim/samples/GlobalArrayServerApplet.java
+++ b/src/main/java/com/licel/jcardsim/samples/GlobalArrayServerApplet.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2022 Licel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.licel.jcardsim.samples;
+
+import javacard.framework.*;
+
+/**
+ * Global array server applet.
+ *
+ * <p>Supported APDUs:</p>
+ *
+ * <ul>
+ *     <li><code>CLA=0x10 INS=1</code> Create global byte array with size form <code>P1</code> and fill each byte with data from <code>P2</code></li>
+ *     <li><code>CLA=0x10 INS=2</code> Store global byte array value from <code>CData</code></li>
+ * </ul>
+ */
+
+public class GlobalArrayServerApplet extends BaseApplet implements GlobalArrayAccess{
+    private final static byte CLA = 0x10; 
+    private final static byte INS_INIT_GLOBAL_ARRAY_BYTE = 0x01;
+    private final static byte INS_WRITE_GLOBAL_ARRAY_BYTE = 0x02;
+
+    private final byte[] transientMemory;
+    private static final short MAX_ALLOWED_GLOBAL_ARRAY_SIZE_BYTES = 64;
+
+    private Object globalArray = null;
+
+    protected GlobalArrayServerApplet(){
+        transientMemory = JCSystem.makeTransientByteArray(MAX_ALLOWED_GLOBAL_ARRAY_SIZE_BYTES, JCSystem.CLEAR_ON_DESELECT);
+        register();
+    }
+
+    public static void install(byte[] bArray, short bOffset, byte bLength)
+            throws ISOException {
+        new GlobalArrayServerApplet();
+    }
+
+    @Override
+    public void process(APDU apdu) throws ISOException {
+        if(selectingApplet()) {
+            return;
+        }
+
+        byte[] buffer = apdu.getBuffer();
+
+        // Verify CLA
+        if( buffer[ISO7816.OFFSET_CLA] != CLA){
+            ISOException.throwIt(ISO7816.SW_CLA_NOT_SUPPORTED);
+        }
+
+        switch(buffer[ISO7816.OFFSET_INS]){
+            case INS_INIT_GLOBAL_ARRAY_BYTE:
+                initGlobalArrayByte(apdu);
+                return;
+            case INS_WRITE_GLOBAL_ARRAY_BYTE:
+                writeGlobalArrayByte(apdu);
+                return;
+
+            default:
+                ISOException.throwIt(ISO7816.SW_INS_NOT_SUPPORTED);
+
+        }
+    } 
+
+    public Shareable getShareableInterfaceObject(AID clientAID, byte parameter) {
+        return this;
+    }
+
+
+    private void initGlobalArrayByte(APDU apdu) {
+        byte[] buffer = apdu.getBuffer();
+        byte size = buffer[ISO7816.OFFSET_P1];
+
+        if( (size > MAX_ALLOWED_GLOBAL_ARRAY_SIZE_BYTES) || (size == 0) ) {
+            ISOException.throwIt(ISO7816.SW_WRONG_LENGTH);
+        }
+
+        byte init_val = buffer[ISO7816.OFFSET_P2];
+        globalArray = JCSystem.makeGlobalArray( JCSystem.ARRAY_TYPE_BYTE,size);
+        for (byte i=0; i<size; i++ ) {
+            ((byte[])globalArray)[i] = init_val;
+        }
+    }
+
+    private void writeGlobalArrayByte(APDU apdu){
+        byte[] buffer = apdu.getBuffer();
+        byte numBytes = buffer[ISO7816.OFFSET_LC];
+        if( (numBytes > MAX_ALLOWED_GLOBAL_ARRAY_SIZE_BYTES) || (numBytes == 0) ){
+            ISOException.throwIt(ISO7816.SW_WRONG_LENGTH);
+        }
+
+        byte bytesRead = (byte)apdu.setIncomingAndReceive();
+        byte bufferOffset = 0;
+
+        while(bytesRead >0){
+            Util.arrayCopyNonAtomic(buffer, ISO7816.OFFSET_CDATA, transientMemory, bufferOffset, bytesRead);
+            bufferOffset += bytesRead;
+            bytesRead = (byte)apdu.receiveBytes(ISO7816.OFFSET_CDATA);
+        }
+
+        for (byte i=0; i<numBytes; i++ ) {
+            ((byte[])globalArray)[i] = transientMemory[i];
+        }
+    }
+
+    @Override
+    public Object getGlobalArrayRef() {
+        return globalArray;
+    }
+
+
+}

--- a/src/test/java/com/licel/jcardsim/base/AppletShareableTest.java
+++ b/src/test/java/com/licel/jcardsim/base/AppletShareableTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 Licel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.licel.jcardsim.base;
+
+import com.licel.jcardsim.samples.GlobalArrayClientApplet;
+import com.licel.jcardsim.samples.GlobalArrayServerApplet;
+import com.licel.jcardsim.utils.AIDUtil;
+
+import javacard.framework.AID;
+import javacard.framework.JCSystem;
+import junit.framework.Test;
+import junit.framework.TestCase;
+
+public class AppletShareableTest extends TestCase{
+    byte[] serverAppletAIDBytes = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09 };
+    AID serverAppletAID;
+    public AppletShareableTest(String name){
+        super(name);
+    }
+
+    public void testGetShareableApplet(){
+        String shareableAppletAIDStr = "010203040506070809";
+        AID shareableAppletAID = AIDUtil.create(shareableAppletAIDStr);
+
+        Simulator instance = new Simulator();
+        assertEquals(instance.installApplet(shareableAppletAID,GlobalArrayServerApplet.class).equals(shareableAppletAID),true);
+        assertEquals(instance.selectApplet(shareableAppletAID), true);
+
+        assertNotNull(JCSystem.getAppletShareableInterfaceObject(shareableAppletAID, (byte) 0));
+
+    }
+
+    public void testGetNotShareableApplet(){
+        String appletAIDStr = "090807060504030201";
+        AID appletAID = AIDUtil.create(appletAIDStr);
+
+        byte[] clientAppletPar = new byte[1+serverAppletAIDBytes.length];
+        clientAppletPar[0] = (byte)serverAppletAIDBytes.length;
+        System.arraycopy(serverAppletAIDBytes, 0, clientAppletPar, 1, serverAppletAIDBytes.length);
+
+        Simulator instance = new Simulator();
+        assertEquals(instance.installApplet(appletAID,GlobalArrayClientApplet.class,clientAppletPar,(short)0,(byte)clientAppletPar.length).equals(appletAID),true);
+        assertEquals(instance.selectApplet(appletAID), true);
+
+        assertNull(JCSystem.getAppletShareableInterfaceObject(appletAID, (byte) 0));
+    }
+}

--- a/src/test/java/com/licel/jcardsim/base/GlobalArrayTest.java
+++ b/src/test/java/com/licel/jcardsim/base/GlobalArrayTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2022 Licel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.licel.jcardsim.base;
+
+import com.licel.jcardsim.samples.GlobalArrayClientApplet;
+import com.licel.jcardsim.samples.GlobalArrayServerApplet;
+import com.licel.jcardsim.utils.AIDUtil;
+
+import org.bouncycastle.util.Arrays;
+
+import javacard.framework.AID;
+import javacard.framework.ISO7816;
+import javacard.framework.JCSystem;
+import javacard.framework.Util;
+import junit.framework.TestCase;
+
+public class GlobalArrayTest extends TestCase {
+    byte[] serverAppletAIDBytes = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09 };
+    byte[] wrongServerAppletAIDBytes = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x00 };
+    AID serverAppletAID;
+
+    String clientAppletAIDStr;
+    AID clientAppletAID;
+    byte[] clientAppletPar = null;
+
+    byte[] bytesForTest = null;
+    boolean[] booleansForTest = null;
+    short[] shortsForTest = null;
+
+    public GlobalArrayTest(String testName){
+        super(testName);
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        serverAppletAID = AIDUtil.create(serverAppletAIDBytes);
+        clientAppletAIDStr = "090807060504030201";
+        clientAppletAID = AIDUtil.create(clientAppletAIDStr);
+        clientAppletPar = new byte[1+serverAppletAIDBytes.length];
+        clientAppletPar[0] = (byte)serverAppletAIDBytes.length;
+        System.arraycopy(serverAppletAIDBytes, 0, clientAppletPar, 1, serverAppletAIDBytes.length);
+
+        bytesForTest = new byte[32];
+        for(byte i = 0; i<32 ; i++){
+            bytesForTest[i] = i;
+        }
+
+        booleansForTest = new boolean[32];
+        for(byte i = 0; i<32 ; i++){
+            if((i%2) != 0)
+                booleansForTest[i] = true;
+            else
+                booleansForTest[i] = true;
+        }
+
+        shortsForTest = new short[32];
+        for(byte i = 0; i<32 ; i++){
+            shortsForTest[i] = (short)i;
+        }
+
+
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+        
+    }
+
+    /**
+     * Test access global byte array by server applet
+    * */
+    public void testAccessGlobalArrayByteByServerApplet(){
+        Simulator instance = new Simulator();
+
+        assertEquals(instance.installApplet(serverAppletAID,GlobalArrayServerApplet.class).equals(serverAppletAID),true);
+        assertEquals(instance.selectApplet(serverAppletAID), true);
+
+        // Get global array reference from server applet
+        GlobalArrayServerApplet serverApplet = (GlobalArrayServerApplet)JCSystem.getAppletShareableInterfaceObject(serverAppletAID,(byte)0);
+        Object globalArray = serverApplet.getGlobalArrayRef();
+
+        // Check global array must be null, because it has not been created yet
+        assertNull(globalArray);
+
+        // Send C-APDU to create the byte global array for 32-byte size and filled with 0xCC
+        byte[] response1 = instance.transmitCommand(new byte[]{0x10, 0x01, 32, (byte)0xCC});
+
+        // Check command succeeded
+        assertEquals(ISO7816.SW_NO_ERROR, Util.getShort(response1, (short) 0));
+
+        // Get global array reference and check not null
+        globalArray = serverApplet.getGlobalArrayRef();
+        assertNotNull(globalArray);
+
+        // Check global array content
+        for( byte i = 0 ; i < 32; i++){
+            assertEquals((byte)0xCC,((byte[]) globalArray)[i]);
+        }
+
+        // Create C-APDU to write 32 test bytes to global array
+        byte[] commandAPDUHeaderWithLc = new byte[]{0x10, 0x02, 0, 0, 32};
+        byte[] sendAPDU = new byte[5+32];
+        System.arraycopy(commandAPDUHeaderWithLc, 0, sendAPDU, 0, 5);
+        System.arraycopy(bytesForTest, 0, sendAPDU, 5, 32);
+
+        // Send C-APDU
+        byte[] response2 = instance.transmitCommand(sendAPDU);
+        // Check command succeeded
+        assertEquals(ISO7816.SW_NO_ERROR, Util.getShort(response2, (short) 0));
+        // Check the global array with the writen data
+        assertEquals(Arrays.areEqual(bytesForTest, (byte[]) globalArray), true);
+
+    }
+
+    /**
+     * Test access the global byte array with the client applet
+    * */
+    public void testAccessGlobalArrayByteByClientApplet(){
+        Simulator instance = new Simulator();
+
+        // Install server and client applet
+        assertEquals(instance.installApplet(serverAppletAID,GlobalArrayServerApplet.class).equals(serverAppletAID),true);
+        assertEquals(instance.installApplet(clientAppletAID,GlobalArrayClientApplet.class,clientAppletPar,(short)0,(byte)clientAppletPar.length).equals(clientAppletAID),true);
+
+        // Select server applet
+        assertEquals(instance.selectApplet(serverAppletAID),true);
+
+        // Send C-APDU to create the byte global array for 32-byte size and filled with 0x5A
+        byte[] response1 = instance.transmitCommand(new byte[]{0x10, 0x01, 32, (byte) 0x5A});
+
+        // Check command succeeded
+        assertEquals(ISO7816.SW_NO_ERROR, Util.getShort(response1, (short) 0));
+
+        // Select client applet
+        assertEquals(instance.selectApplet(clientAppletAID),true);
+        // Send C-APDU to read the global byte array for 32 bytes
+        byte[] response2 = instance.transmitCommand(new byte[]{0x10, 0x01, 0x00, 0x00, 32});
+        // Check command succeeded
+        assertEquals(ISO7816.SW_NO_ERROR, Util.getShort(response2, (short) 32));
+
+        // Check global array content
+        for( byte i = 0 ; i < 32; i++){
+            assertEquals((byte)0x5A,((byte[]) response2)[i]);
+        }
+
+         // Create C-APDU to write 32 test bytes to global array
+         byte[] commandAPDUHeaderWithLc = new byte[]{0x10, 0x02, 0, 0, 32};
+         byte[] sendAPDU = new byte[5+32];
+         System.arraycopy(commandAPDUHeaderWithLc, 0, sendAPDU, 0, 5);
+         System.arraycopy(bytesForTest, 0, sendAPDU, 5, 32);
+ 
+         // Send C-APDU
+         byte[] response3 = instance.transmitCommand(sendAPDU);
+         // Check command succeeded
+         assertEquals(ISO7816.SW_NO_ERROR, Util.getShort(response3, (short) 0));
+
+        // Send C-APDU to read the global byte array for 32 bytes
+        byte[] response4 = instance.transmitCommand(new byte[]{0x10, 0x01, 0x00, 0x00, 32});
+        // Check command succeeded
+        assertEquals(ISO7816.SW_NO_ERROR, Util.getShort(response4, (short) 32));
+
+         // Check the global array with the writen data
+        byte[] globalArrayBytes = new byte[32];
+        System.arraycopy(response4, 0, globalArrayBytes, 0, globalArrayBytes.length);
+        assertEquals(Arrays.areEqual(bytesForTest, (byte[]) globalArrayBytes), true);
+    }
+    
+}

--- a/src/test/java/com/licel/jcardsim/base/TransientMemoryTest.java
+++ b/src/test/java/com/licel/jcardsim/base/TransientMemoryTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 Licel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.licel.jcardsim.base;
 
 import com.licel.jcardsim.samples.Sha1Applet;
@@ -157,5 +172,77 @@ public class TransientMemoryTest extends TestCase {
         responseApdu = new ResponseAPDU(result);
         assertEquals(0x9000, responseApdu.getSW());
         assertEquals(Arrays.toString(new byte[20]), Arrays.toString(responseApdu.getData()));
+    }
+
+    public void testGlobalArrayBooleanType(){
+        final short size = 1;
+
+        TransientMemory transientMemory = new TransientMemory();
+        boolean[] globalBooleans = (boolean[])transientMemory.makeGlobalArray(JCSystem.ARRAY_TYPE_BOOLEAN, size);
+        globalBooleans[0] = true;
+
+        transientMemory.clearOnDeselect();
+        assertTrue(globalBooleans[0]);
+
+        transientMemory.clearOnReset();
+        assertTrue(!globalBooleans[0]);
+    }
+
+    public void testGlobalArrayByteType(){
+        final short size = 1;
+
+        TransientMemory transientMemory = new TransientMemory();
+        byte[] globalBytes = (byte[])transientMemory.makeGlobalArray(JCSystem.ARRAY_TYPE_BYTE, size);
+        globalBytes[0] = (byte)0x5A;
+
+        transientMemory.clearOnDeselect();
+        assertTrue(globalBytes[0] == 0x5A);
+
+        transientMemory.clearOnReset();
+        assertTrue(globalBytes[0] == 0);
+    }
+
+    public void testGlobalArrayShortType(){
+        final short size = 1;
+
+        TransientMemory transientMemory = new TransientMemory();
+        short[] globalShorts = (short[])transientMemory.makeGlobalArray(JCSystem.ARRAY_TYPE_SHORT, size);
+        globalShorts[0] = (short)0x5A7F;
+
+        transientMemory.clearOnDeselect();
+        assertTrue(globalShorts[0] == 0x5A7F);
+
+        transientMemory.clearOnReset();
+        assertTrue(globalShorts[0] == 0);
+    }
+
+    public void testGlobalArrayObjectType(){
+        final Object dummy = new Object();
+
+        final short size = 1;
+
+        TransientMemory transientMemory = new TransientMemory();
+        Object[] globalObjects = (Object[])transientMemory.makeGlobalArray(JCSystem.ARRAY_TYPE_OBJECT, size);
+        globalObjects[0] = dummy;
+
+        transientMemory.clearOnDeselect();
+        assertTrue(globalObjects[0] == dummy);
+
+        transientMemory.clearOnReset();
+        assertTrue(globalObjects[0] == null);
+    }
+
+    public void testGlobalArrayInvalidType() {
+        final byte invalid = JCSystem.ARRAY_TYPE_INT;
+        final short size = 1;
+        TransientMemory transientMemory = new TransientMemory();
+
+        try {
+            transientMemory.makeGlobalArray(invalid, size);
+            fail("No exception");
+        }
+        catch (SystemException e) {
+            assertEquals(SystemException.ILLEGAL_VALUE, e.getReason());
+        }
     }
 }


### PR DESCRIPTION
### ****Fix issue #178**** 

**Modified files**

- main/com.licel.jcardsim.base.TransientMemory.java - Implemented makeGlobalArray(byte type, short length) method
- test/com.licel.jcardsim.base.TransientMemoryTest  - Added test cases for global array

**New files**

- main/com.licel.jcardsim.samples.GlobalArrayServerApplet.java - Server applet for test global array
- main/com.licel.jcardsim.samples.GlobalArrayClientApplet.java - Client applet for test global array
- main/com.licel.jcardsim.samples.GlobalArrayAccess.java - Extended interface of Shareable interface for getting global array reference. It must be implemented in Server applet class.
- test/com.licel.jcardsim.base.AppletShareableTest.java - Test shareable applet
- test/com.licel.jcardsim.base.GlobalArrayTest.java - Test global array invoked to make in the server applet can be accessed by the client applet