### PR TITLE
Add SymmetricCipherImpl.checkKeyCompatibility to check mismatched AES/DES cipher and key type

### DIFF
--- a/src/main/java/com/licel/jcardsim/crypto/SymmetricCipherImpl.java
+++ b/src/main/java/com/licel/jcardsim/crypto/SymmetricCipherImpl.java
@@ -15,10 +15,10 @@
  */
 package com.licel.jcardsim.crypto;
 
-import javacard.framework.JCSystem;
-import javacard.framework.Util;
+import javacard.framework.*;
 import javacard.security.CryptoException;
 import javacard.security.Key;
+import javacard.security.KeyBuilder;
 import javacardx.crypto.Cipher;
 import org.bouncycastle.crypto.BufferedBlockCipher;
 import org.bouncycastle.crypto.modes.CBCBlockCipher;
@@ -38,6 +38,7 @@ public class SymmetricCipherImpl extends Cipher {
     byte algorithm;
     BufferedBlockCipher engine;
     boolean isInitialized;
+
 
     public SymmetricCipherImpl(byte algorithm) {
         this.algorithm = algorithm;
@@ -108,6 +109,10 @@ public class SymmetricCipherImpl extends Cipher {
         if (!(theKey instanceof SymmetricKeyImpl)) {
             CryptoException.throwIt(CryptoException.ILLEGAL_VALUE);
         }
+        if( !checkKeyCompatibility(theKey)){
+            CryptoException.throwIt(CryptoException.ILLEGAL_VALUE);
+        }
+
         SymmetricKeyImpl key = (SymmetricKeyImpl) theKey;
         switch (algorithm) {
             case ALG_DES_CBC_NOPAD:
@@ -144,6 +149,43 @@ public class SymmetricCipherImpl extends Cipher {
                 break;
         }
     }
+
+    private boolean checkKeyCompatibility(Key theKey){
+        switch(theKey.getType()){
+            case KeyBuilder.TYPE_DES:
+                case KeyBuilder.TYPE_DES_TRANSIENT_RESET:
+                    case KeyBuilder.TYPE_DES_TRANSIENT_DESELECT:
+                if( (algorithm == Cipher.ALG_DES_CBC_NOPAD) ||
+                        (algorithm == Cipher.ALG_DES_CBC_ISO9797_M1) ||
+                        (algorithm == Cipher.ALG_DES_CBC_ISO9797_M2) ||
+                        (algorithm == Cipher.ALG_DES_CBC_PKCS5) ||
+                        (algorithm == Cipher.ALG_DES_ECB_NOPAD) ||
+                        (algorithm == Cipher.ALG_DES_ECB_ISO9797_M1) ||
+                        (algorithm == Cipher.ALG_DES_ECB_ISO9797_M2) ||
+                        (algorithm == Cipher.ALG_DES_ECB_PKCS5))
+                    return true;
+                break;
+
+            case KeyBuilder.TYPE_AES:
+                case KeyBuilder.TYPE_AES_TRANSIENT_RESET:
+                    case KeyBuilder.TYPE_AES_TRANSIENT_DESELECT:
+                if( (algorithm == Cipher.ALG_AES_CTR) ||
+                        (algorithm == Cipher.ALG_AES_BLOCK_128_CBC_NOPAD) ||
+                        (algorithm == Cipher.ALG_AES_BLOCK_128_ECB_NOPAD) ||
+                        (algorithm == Cipher.ALG_AES_CBC_ISO9797_M1) ||
+                        (algorithm == Cipher.ALG_AES_CBC_ISO9797_M2) ||
+                        (algorithm == Cipher.ALG_AES_CBC_PKCS5) ||
+                        (algorithm == Cipher.ALG_AES_ECB_ISO9797_M1) ||
+                        (algorithm == Cipher.ALG_AES_ECB_ISO9797_M2) ||
+                        (algorithm == Cipher.ALG_AES_ECB_PKCS5))
+                    return true;
+                break;
+        }
+
+        return false;
+
+    }
+
     public byte getPaddingAlgorithm() {
         throw new UnsupportedOperationException("Not supported yet.");
     }

--- a/src/main/java/com/licel/jcardsim/samples/SymmetricCipherApplet.java
+++ b/src/main/java/com/licel/jcardsim/samples/SymmetricCipherApplet.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright 2022 Licel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.licel.jcardsim.samples;
+import com.licel.jcardsim.smartcardio.JCSCard;
+import javacard.framework.*;
+import javacard.security.AESKey;
+import javacard.security.DESKey;
+import javacard.security.Key;
+import javacard.security.KeyBuilder;
+import javacardx.crypto.Cipher;
+
+/**
+ * Symmetric Cipher Test Applet is designed to encrypt and decrypt data send from host.
+ * It can operate either only AES or DES key/cipher per time by initiating from key setting.
+ * Support 128 and 192 bit key size
+ *
+ * <p>Supported APDUs:</p>
+ *
+ * <ul>
+ *     <li><code>CLA=0x10 INS=0x10</code> Set AES Key from <code>CData</code> with <code>P1</code> as key size 128 or 192 bits</li>
+ *     <li><code>CLA=0x10 INS=0x11</code> Encrypt AES data in <code>CData</code> with cipher algorithm in <code>P1</code></li>
+ *     <li><code>CLA=0x10 INS=0x12</code> Decrypt AES data in <code>CData</code>with cipher algorithm in <code>P1</code></li>
+ *     <li><code>CLA=0x20 INS=0x10</code> Set DES Key from <code>CData</code> with <code>P1</code> as key size  DES3_2KEY or DES3_3KEY</li>
+ *     <li><code>CLA=0x20 INS=0x11</code> Encrypt DES data in <code>CData</code> with cipher algorithm in <code>P1</code></li>
+ *     <li><code>CLA=0x20 INS=0x12</code> Decrypt DES data in <code>CData</code>with cipher algorithm in <code>P1</code></li>
+ * </ul>
+ */
+public class SymmetricCipherApplet extends  BaseApplet {
+    private final static byte CLA_AES = 0x10;
+    private final static byte CLA_DES = 0x20;
+    private final static byte INS_AES_SET_KEY = 0x10;
+    private final static byte INS_AES_ENCRYPT = 0x11;
+    private final static byte INS_AES_DECRYPT = 0x12;
+
+    private final static byte INS_DES_SET_KEY = 0x10;
+    private final static byte INS_DES_ENCRYPT = 0x11;
+    private final static byte INS_DES_DECRYPT = 0x12;
+
+    private Key secreteKey = null;
+
+    private Cipher cipher = null;
+
+    private byte[] transientMemory = null;
+    private final static short MAX_DATA_BYTE_SIZE = 32;
+    public static void install(byte[] bArray, short bOffset, byte bLength)
+            throws ISOException {
+        new SymmetricCipherApplet();
+    }
+
+    protected SymmetricCipherApplet(){
+        transientMemory = JCSystem.makeTransientByteArray(MAX_DATA_BYTE_SIZE, JCSystem.CLEAR_ON_DESELECT);
+        register();
+    }
+
+    @Override
+    public void process(APDU apdu) throws ISOException {
+        if(selectingApplet()) return;
+
+        byte[] buffer = apdu.getBuffer();
+        switch(buffer[ISO7816.OFFSET_CLA]){
+            case CLA_AES:
+                doAESMode(apdu);
+                break;
+
+            case CLA_DES :
+                doDESMode(apdu);
+                break;
+
+            default:
+                ISOException.throwIt(ISO7816.SW_CLA_NOT_SUPPORTED);
+                break;
+        }
+    }
+
+    private void doAESMode(APDU apdu) {
+        byte[] buffer = apdu.getBuffer();
+        switch(buffer[ISO7816.OFFSET_INS]){
+            case INS_AES_SET_KEY:
+                aesSetKey(apdu);
+                break;
+            case INS_AES_ENCRYPT:
+                aesEncrypt(apdu);
+                break;
+            case INS_AES_DECRYPT:
+                aesDecrypt(apdu);
+                break;
+            default:
+                ISOException.throwIt(ISO7816.SW_INS_NOT_SUPPORTED);
+        }
+    }
+
+    private void aesSetKey(APDU apdu) {
+        byte[] buffer = apdu.getBuffer();
+
+        short keyBitLength = (short) (buffer[ISO7816.OFFSET_P1] & 0x00FF);
+        if((keyBitLength != KeyBuilder.LENGTH_AES_128) &&
+                (keyBitLength != KeyBuilder.LENGTH_AES_192)  ) {
+            ISOException.throwIt(ISO7816.SW_WRONG_P1P2);
+        }
+
+        byte apdu_Lc      = buffer[ISO7816.OFFSET_LC];
+        byte[] aesKeyBytes = new byte[apdu_Lc];
+        byte bytesRead = (byte) apdu.setIncomingAndReceive();
+
+        byte bufferOffset = 0;
+
+        while(bytesRead >0){
+            Util.arrayCopyNonAtomic(buffer, ISO7816.OFFSET_CDATA, aesKeyBytes, bufferOffset, bytesRead);
+            bufferOffset += bytesRead;
+            bytesRead = (byte) apdu.receiveBytes(ISO7816.OFFSET_CDATA);
+        }
+
+        secreteKey = KeyBuilder.buildKey(KeyBuilder.TYPE_AES, keyBitLength, false);
+        ((AESKey) secreteKey).setKey(aesKeyBytes, (short) 0);
+    }
+
+    private void aesEncrypt(APDU apdu) {
+        byte[] buffer = apdu.getBuffer();
+        byte aesCipherAlg = buffer[ISO7816.OFFSET_P1];
+        byte apdu_Lc = buffer[ISO7816.OFFSET_LC];
+
+        if( apdu_Lc > MAX_DATA_BYTE_SIZE) {
+            ISOException.throwIt(ISO7816.SW_WRONG_LENGTH);
+        }
+        byte[] toBeEncryptedData = new byte[apdu_Lc];
+        byte bytesRead = (byte) apdu.setIncomingAndReceive();
+        byte bufferOffset = 0;
+
+        while(bytesRead >0){
+            Util.arrayCopyNonAtomic(buffer, ISO7816.OFFSET_CDATA, toBeEncryptedData, bufferOffset, bytesRead);
+            bufferOffset += bytesRead;
+            bytesRead = (byte) apdu.receiveBytes(ISO7816.OFFSET_CDATA);
+        }
+
+        cipher = Cipher.getInstance(aesCipherAlg, false);
+        cipher.init(secreteKey,Cipher.MODE_ENCRYPT);
+        cipher.doFinal(toBeEncryptedData,(short)0, (short) toBeEncryptedData.length,transientMemory, (short) 0);
+
+        short le = apdu.setOutgoing();
+        apdu.setOutgoingLength(le);
+        apdu.sendBytesLong(transientMemory, (short) 0, le);
+    }
+
+    private void aesDecrypt(APDU apdu) {
+        byte[] buffer = apdu.getBuffer();
+        byte aesCipherAlg = buffer[ISO7816.OFFSET_P1];
+
+        byte apdu_Lc = buffer[ISO7816.OFFSET_LC];
+
+        if( apdu_Lc > MAX_DATA_BYTE_SIZE) {
+            ISOException.throwIt(ISO7816.SW_WRONG_LENGTH);
+        }
+        byte[] encryptedData = new byte[apdu_Lc];
+        byte bytesRead = (byte) apdu.setIncomingAndReceive();
+        byte bufferOffset = 0;
+
+        while(bytesRead >0){
+            Util.arrayCopyNonAtomic(buffer, ISO7816.OFFSET_CDATA, encryptedData, bufferOffset, bytesRead);
+            bufferOffset += bytesRead;
+            bytesRead = (byte) apdu.receiveBytes(ISO7816.OFFSET_CDATA);
+        }
+
+        cipher = Cipher.getInstance(aesCipherAlg, false);
+        cipher.init(secreteKey,Cipher.MODE_DECRYPT);
+        cipher.doFinal(encryptedData,(short)0, (short) encryptedData.length,transientMemory, (short) 0);
+
+        short le = apdu.setOutgoing();
+        apdu.setOutgoingLength(le);
+        apdu.sendBytesLong(transientMemory, (short) 0, le);
+    }
+
+    private void doDESMode(APDU apdu) {
+        byte[] buffer = apdu.getBuffer();
+        switch(buffer[ISO7816.OFFSET_INS]){
+            case INS_DES_SET_KEY:
+                desSetKey(apdu);
+                break;
+            case INS_DES_ENCRYPT:
+                desEncrypt(apdu);
+                break;
+            case INS_DES_DECRYPT:
+                desDecrypt(apdu);
+                break;
+            default:
+                ISOException.throwIt(ISO7816.SW_INS_NOT_SUPPORTED);
+        }
+    }
+
+    private void desSetKey(APDU apdu) {
+        byte[] buffer = apdu.getBuffer();
+
+        short keyBitLength = (short) (buffer[ISO7816.OFFSET_P1] & 0x00FF);
+        if((keyBitLength != KeyBuilder.LENGTH_DES) &&
+                (keyBitLength != KeyBuilder.LENGTH_DES3_2KEY) &&
+                (keyBitLength != KeyBuilder.LENGTH_DES3_3KEY)    ) {
+            ISOException.throwIt(ISO7816.SW_WRONG_P1P2);
+        }
+
+        byte apdu_Lc      = buffer[ISO7816.OFFSET_LC];
+        byte[] desKeyBytes = new byte[apdu_Lc];
+        byte bytesRead = (byte) apdu.setIncomingAndReceive();
+
+        byte bufferOffset = 0;
+
+        while(bytesRead >0){
+            Util.arrayCopyNonAtomic(buffer, ISO7816.OFFSET_CDATA, desKeyBytes, bufferOffset, bytesRead);
+            bufferOffset += bytesRead;
+            bytesRead = (byte) apdu.receiveBytes(ISO7816.OFFSET_CDATA);
+        }
+
+        secreteKey = KeyBuilder.buildKey(KeyBuilder.TYPE_DES, keyBitLength, false);
+        ((DESKey) secreteKey).setKey(desKeyBytes, (short) 0);
+    }
+
+    private void desEncrypt(APDU apdu) {
+        byte[] buffer = apdu.getBuffer();
+        byte desCipherAlg = buffer[ISO7816.OFFSET_P1];
+        byte apdu_Lc = buffer[ISO7816.OFFSET_LC];
+
+        if( apdu_Lc > MAX_DATA_BYTE_SIZE) {
+            ISOException.throwIt(ISO7816.SW_WRONG_LENGTH);
+        }
+        byte[] toBeEncryptedData = new byte[apdu_Lc];
+        byte bytesRead = (byte) apdu.setIncomingAndReceive();
+        byte bufferOffset = 0;
+
+        while(bytesRead >0){
+            Util.arrayCopyNonAtomic(buffer, ISO7816.OFFSET_CDATA, toBeEncryptedData, bufferOffset, bytesRead);
+            bufferOffset += bytesRead;
+            bytesRead = (byte) apdu.receiveBytes(ISO7816.OFFSET_CDATA);
+        }
+
+        cipher = Cipher.getInstance(desCipherAlg, false);
+        cipher.init(secreteKey,Cipher.MODE_ENCRYPT);
+        cipher.doFinal(toBeEncryptedData,(short)0, (short) toBeEncryptedData.length,transientMemory, (short) 0);
+
+        short le = apdu.setOutgoing();
+        apdu.setOutgoingLength(le);
+        apdu.sendBytesLong(transientMemory, (short) 0, le);
+    }
+
+    private void desDecrypt(APDU apdu) {
+        byte[] buffer = apdu.getBuffer();
+        byte desCipherAlg = buffer[ISO7816.OFFSET_P1];
+
+        byte apdu_Lc = buffer[ISO7816.OFFSET_LC];
+
+        if( apdu_Lc > MAX_DATA_BYTE_SIZE) {
+            ISOException.throwIt(ISO7816.SW_WRONG_LENGTH);
+        }
+        byte[] encryptedData = new byte[apdu_Lc];
+        byte bytesRead = (byte) apdu.setIncomingAndReceive();
+        byte bufferOffset = 0;
+
+        while(bytesRead >0){
+            Util.arrayCopyNonAtomic(buffer, ISO7816.OFFSET_CDATA, encryptedData, bufferOffset, bytesRead);
+            bufferOffset += bytesRead;
+            bytesRead = (byte) apdu.receiveBytes(ISO7816.OFFSET_CDATA);
+        }
+
+        cipher = Cipher.getInstance(desCipherAlg, false);
+        cipher.init(secreteKey,Cipher.MODE_DECRYPT);
+        cipher.doFinal(encryptedData,(short)0, (short) encryptedData.length,transientMemory, (short) 0);
+
+        short le = apdu.setOutgoing();
+        apdu.setOutgoingLength(le);
+        apdu.sendBytesLong(transientMemory, (short) 0, le);
+    }
+}

--- a/src/test/java/com/licel/jcardsim/crypto/SymmetricCipherImplTest.java
+++ b/src/test/java/com/licel/jcardsim/crypto/SymmetricCipherImplTest.java
@@ -15,10 +15,11 @@
  */
 package com.licel.jcardsim.crypto;
 
-import javacard.framework.Util;
-import javacard.security.AESKey;
-import javacard.security.Key;
-import javacard.security.KeyBuilder;
+import com.licel.jcardsim.base.Simulator;
+import com.licel.jcardsim.samples.SymmetricCipherApplet;
+import com.licel.jcardsim.utils.AIDUtil;
+import javacard.framework.*;
+import javacard.security.*;
 import javacardx.crypto.Cipher;
 import junit.framework.TestCase;
 import org.bouncycastle.util.Arrays;
@@ -256,5 +257,231 @@ public class SymmetricCipherImplTest extends TestCase {
         processedBytes = engine.doFinal(encryptedEtalonMsg, (short) 0, (short) encryptedEtalonMsg.length, decrypted, (short) 0);
         assertEquals(processedBytes, msg.length);
         assertEquals(true, Arrays.areEqual(decrypted, msg));
+    }
+
+    /**
+     * Test mismatched Cipher AES algorithm and key DES type
+     */
+    public void testMismatchedCipherAESAlgorithmAndKeyDESType(){
+        Cipher engineAES = Cipher.getInstance(Cipher.ALG_AES_BLOCK_128_CBC_NOPAD,false);
+        DESKey desKey = (DESKey) KeyBuilder.buildKey(KeyBuilder.TYPE_DES_TRANSIENT_RESET,KeyBuilder.LENGTH_DES, false);
+        desKey.setKey(Hex.decode(DES_KEY),(short)0);
+
+        try {
+            engineAES.init(desKey, Cipher.MODE_ENCRYPT);
+            fail("No exception");
+        }
+        catch (CryptoException e) {
+            assertEquals(CryptoException.ILLEGAL_VALUE, e.getReason());
+        }
+    }
+
+    /**
+     * Test mismatched Cipher DES algorithm and key AES type
+     */
+    public void testMismatchedCipherDESAlgorithmAndKeyAESType(){
+        Cipher engineDES = Cipher.getInstance(Cipher.ALG_DES_ECB_NOPAD,false);
+        Key aeskey = KeyBuilder.buildKey(KeyBuilder.TYPE_AES, KeyBuilder.LENGTH_AES_192, false);
+
+        byte[] etalonKey = Hex.decode(AES_ECB_192_TEST[0]);
+        short keyLenInBytes = (short) (KeyBuilder.LENGTH_AES_192 / 8);
+        byte[] key = new byte[keyLenInBytes];
+        Util.arrayCopy(etalonKey, (short) 0, key, (short) 0, (short) etalonKey.length);
+        ((AESKey)aeskey).setKey(key, (short) 0);
+
+        try {
+            engineDES.init(aeskey, Cipher.MODE_ENCRYPT);
+            fail("No exception");
+        }
+        catch (CryptoException e) {
+            assertEquals(CryptoException.ILLEGAL_VALUE, e.getReason());
+        }
+    }
+
+    /**
+     * Test AES encryption/decryption and try DES cipher with AES key type
+     */
+    public void testSymmetricCipherAESEncryptionInApplet(){
+        Simulator instance = new Simulator();
+
+        String appletAIDStr = "010203040506070809";
+        AID appletAID = AIDUtil.create(appletAIDStr);
+        instance.installApplet(appletAID, SymmetricCipherApplet.class);
+        instance.selectApplet(appletAID);
+
+        // 1. Send C-APDU to set AES key
+        // Create C-APDU to send 128-bit AES key in CData
+        byte[] key = Hex.decode(AES_CBC_128_TEST[0]);
+        short keyLen = KeyBuilder.LENGTH_AES_128/8;
+        byte[] commandAPDUHeaderWithLc = new byte[]{0x10, 0x10, (byte) KeyBuilder.LENGTH_AES_128, 0, (byte) keyLen};
+        byte[] sendAPDU = new byte[5+keyLen];
+        System.arraycopy(commandAPDUHeaderWithLc, 0, sendAPDU, 0, 5);
+        System.arraycopy(key, 0, sendAPDU, 5, keyLen);
+
+        // Send C-APDU
+        byte[] response = instance.transmitCommand(sendAPDU);
+        // Check command succeeded
+        assertEquals(ISO7816.SW_NO_ERROR, Util.getShort(response, (short) 0));
+
+        // 2. Send C-APDU to encrypt data with ALG_AES_BLOCK_128_CBC_NOPAD
+        // Create C-APDU to send data to encrypt and read the encrypted back
+        byte[] data = Hex.decode(AES_CBC_128_TEST[1]);
+        byte apdu_Lc = (byte) data.length;
+
+        commandAPDUHeaderWithLc = new byte[]{0x10, 0x11, Cipher.ALG_AES_BLOCK_128_CBC_NOPAD, 0, apdu_Lc};
+        sendAPDU = new byte[5+apdu_Lc+1];
+        System.arraycopy(commandAPDUHeaderWithLc, 0, sendAPDU, 0, 5);
+        System.arraycopy(data, 0, sendAPDU, 5, apdu_Lc);
+
+        // Set Le
+        byte apdu_Le = (byte) data.length;
+        sendAPDU[5+apdu_Lc] = apdu_Le;
+
+        // Send C-APDU to encrypt data
+        response = instance.transmitCommand(sendAPDU);
+        // Check command succeeded
+        assertEquals(ISO7816.SW_NO_ERROR, Util.getShort(response, apdu_Le));
+
+        byte[] encryptedData = new byte[apdu_Le];
+        System.arraycopy(response, 0, encryptedData, 0, encryptedData.length);
+
+        // Prove that encrypted data is not equal the original one
+        assertFalse( Arrays.areEqual(encryptedData, data) );
+
+        // 3. Send C-APDU to decrypt data with ALG_AES_BLOCK_128_CBC_NOPAD and read back to check
+        // Create C-APDU to decrypt data
+        apdu_Lc = (byte) encryptedData.length;
+        commandAPDUHeaderWithLc = new byte[]{0x10, 0x12, Cipher.ALG_AES_BLOCK_128_CBC_NOPAD, 0, apdu_Lc};
+        sendAPDU = new byte[5+apdu_Lc+1];
+        System.arraycopy(commandAPDUHeaderWithLc, 0, sendAPDU, 0, 5);
+        System.arraycopy(encryptedData, 0, sendAPDU, 5, apdu_Lc);
+
+        // Set Le
+        apdu_Le = (byte) encryptedData.length;
+        sendAPDU[5+apdu_Lc] = apdu_Le;
+
+        // Send C-APDU to encrypt data
+        response = instance.transmitCommand(sendAPDU);
+        // Check command succeeded
+        assertEquals(ISO7816.SW_NO_ERROR, Util.getShort(response, apdu_Le));
+
+        byte[] decryptedData = new byte[apdu_Le];
+        System.arraycopy(response, 0, decryptedData, 0, decryptedData.length);
+
+        // Check decrypted data is equal to the original one
+        assertTrue( Arrays.areEqual(decryptedData, data) );
+
+        // 4. Send C-APDU to encrypt data with ALG_DES_CBC_NOPAD, intend to send mismatched cipher DES algorithm
+        data = Hex.decode(MESSAGE_15);
+        apdu_Lc = (byte) data.length;
+
+        commandAPDUHeaderWithLc = new byte[]{0x20, 0x11, Cipher.ALG_DES_CBC_NOPAD, 0, apdu_Lc};
+        sendAPDU = new byte[5+apdu_Lc+1];
+        System.arraycopy(commandAPDUHeaderWithLc, 0, sendAPDU, 0, 5);
+        System.arraycopy(data, 0, sendAPDU, 5, apdu_Lc);
+
+        // Set Le
+        apdu_Le = (byte) data.length;
+        sendAPDU[5+apdu_Lc] = apdu_Le;
+
+        // Send C-APDU to encrypt data
+        response = instance.transmitCommand(sendAPDU);
+        // Check exception for ISO7816.SW_UNKNOWN
+        assertEquals(ISO7816.SW_UNKNOWN, Util.getShort(response, (short) 0));
+
+    }
+    /**
+     * Test DES encryption/decryption and try AES cipher with DES key type
+     */
+    public void testSymmetricCipherDESEncryptionInApplet(){
+        Simulator instance = new Simulator();
+
+        String appletAIDStr = "010203040506070809";
+        AID appletAID = AIDUtil.create(appletAIDStr);
+        instance.installApplet(appletAID, SymmetricCipherApplet.class);
+        instance.selectApplet(appletAID);
+
+        // 1. Send C-APDU to set DES key
+        // Create C-APDU to send DES3_3KEY in CData
+        byte[] key = Hex.decode(DES3_KEY);
+        short keyLen = (short) key.length;
+        byte[] commandAPDUHeaderWithLc = new byte[]{0x20, 0x10, (byte) KeyBuilder.LENGTH_DES3_3KEY, 0, (byte) keyLen};
+        byte[] sendAPDU = new byte[5+keyLen];
+        System.arraycopy(commandAPDUHeaderWithLc, 0, sendAPDU, 0, 5);
+        System.arraycopy(key, 0, sendAPDU, 5, keyLen);
+
+        // Send C-APDU
+        byte[] response = instance.transmitCommand(sendAPDU);
+        // Check command succeeded
+        assertEquals(ISO7816.SW_NO_ERROR, Util.getShort(response, (short) 0));
+
+        // 2. Send C-APDU to encrypt data with ALG_DES_CBC_ISO9797_M1
+        // Create C-APDU to send data to encrypt and read the encrypted back
+        byte[] data = Hex.decode(MESSAGE_15);
+        byte apdu_Lc = (byte) data.length;
+
+        commandAPDUHeaderWithLc = new byte[]{0x20, 0x11, Cipher.ALG_DES_CBC_ISO9797_M1, 0, apdu_Lc};
+        sendAPDU = new byte[5+apdu_Lc+1];
+        System.arraycopy(commandAPDUHeaderWithLc, 0, sendAPDU, 0, 5);
+        System.arraycopy(data, 0, sendAPDU, 5, apdu_Lc);
+
+        // Set Le
+        byte apdu_Le = 16;
+        sendAPDU[5+apdu_Lc] = apdu_Le;
+
+        // Send C-APDU to encrypt data
+        response = instance.transmitCommand(sendAPDU);
+        // Check command succeeded
+        assertEquals(ISO7816.SW_NO_ERROR, Util.getShort(response, apdu_Le));
+
+        byte[] encryptedData = new byte[apdu_Le];
+        System.arraycopy(response, 0, encryptedData, 0, encryptedData.length);
+
+        // Prove that encrypted data is not equal the original one
+        assertFalse( Arrays.areEqual(encryptedData, data) );
+        // Check that encrypted data is correct
+        assertTrue( Arrays.areEqual(encryptedData, Hex.decode(DES3_ENCRYPTED_15[0])));
+
+        // 3. Send C-APDU to decrypt data with ALG_DES_CBC_ISO9797_M1 and read back to check
+        // Create C-APDU to decrypt data
+        apdu_Lc = (byte) encryptedData.length;
+        commandAPDUHeaderWithLc = new byte[]{0x20, 0x12, Cipher.ALG_DES_CBC_ISO9797_M1, 0, apdu_Lc};
+        sendAPDU = new byte[5+apdu_Lc+1];
+        System.arraycopy(commandAPDUHeaderWithLc, 0, sendAPDU, 0, 5);
+        System.arraycopy(encryptedData, 0, sendAPDU, 5, apdu_Lc);
+
+        // Set Le
+        apdu_Le = (byte) data.length;
+        sendAPDU[5+apdu_Lc] = apdu_Le;
+
+        // Send C-APDU to encrypt data
+        response = instance.transmitCommand(sendAPDU);
+        // Check command succeeded
+        assertEquals(ISO7816.SW_NO_ERROR, Util.getShort(response, apdu_Le));
+
+        byte[] decryptedData = new byte[apdu_Le];
+        System.arraycopy(response, 0, decryptedData, 0, decryptedData.length);
+
+        // Check decrypted data is equal to the original one
+        assertTrue( Arrays.areEqual(decryptedData, data) );
+
+        // 4. Send C-APDU to encrypt data with ALG_AES_BLOCK_128_CBC_NOPAD, intend to send mismatched cipher AES algorithm
+        data = Hex.decode(AES_CBC_128_TEST[1]);
+        apdu_Lc = (byte) data.length;
+
+        commandAPDUHeaderWithLc = new byte[]{0x10, 0x11, Cipher.ALG_AES_BLOCK_128_CBC_NOPAD, 0, apdu_Lc};
+        sendAPDU = new byte[5+apdu_Lc+1];
+        System.arraycopy(commandAPDUHeaderWithLc, 0, sendAPDU, 0, 5);
+        System.arraycopy(data, 0, sendAPDU, 5, apdu_Lc);
+
+        // Set Le
+        apdu_Le = (byte) data.length;
+        sendAPDU[5+apdu_Lc] = apdu_Le;
+
+        // Send C-APDU to encrypt data
+        response = instance.transmitCommand(sendAPDU);
+        // Check exception for ISO7816.SW_UNKNOWN
+        assertEquals(ISO7816.SW_UNKNOWN, Util.getShort(response, (short) 0));
+
     }
 }


### PR DESCRIPTION
Fix #94  