### PR TITLE
Support ALG_AES_CCM and ALG_AES_GCM

### DIFF
--- a/src/main/java/com/licel/jcardsim/crypto/AuthenticatedSymmetricCipherImpl.java
+++ b/src/main/java/com/licel/jcardsim/crypto/AuthenticatedSymmetricCipherImpl.java
@@ -1,0 +1,507 @@
+/*
+ * Copyright 2022 Licel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.licel.jcardsim.crypto;
+
+import javacard.framework.JCSystem;
+import javacard.framework.Util;
+import javacard.security.CryptoException;
+import javacard.security.Key;
+import javacard.security.KeyBuilder;
+import javacardx.crypto.AEADCipher;
+import org.bouncycastle.crypto.CipherParameters;
+import org.bouncycastle.crypto.modes.AEADBlockCipher;
+import org.bouncycastle.crypto.modes.CCMBlockCipher;
+import org.bouncycastle.crypto.modes.GCMBlockCipher;
+import org.bouncycastle.crypto.modes.gcm.GCMUtil;
+import org.bouncycastle.crypto.params.AEADParameters;
+import org.bouncycastle.crypto.params.KeyParameter;
+import org.bouncycastle.crypto.params.ParametersWithIV;
+import org.bouncycastle.internal.asn1.cms.GCMParameters;
+import org.bouncycastle.util.Arrays;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+import javax.crypto.spec.GCMParameterSpec;
+
+public class AuthenticatedSymmetricCipherImpl extends AEADCipher {
+    byte algorithm;
+
+    AEADBlockCipher engine;
+    AEADParameters parameters;
+
+    enum CipherState {
+        Uninitialized,
+        Initialized,
+        Finalized
+    };
+
+    CipherState state;
+
+    byte initMode;
+    short initMsgLen;
+    short totalMsgLen;
+    short initAADLen;
+
+    public AuthenticatedSymmetricCipherImpl(byte algorithm) {
+        this.algorithm = algorithm;
+        state = CipherState.Uninitialized;
+    }
+
+    /**
+     * Gets the Cipher algorithm.
+     * @return the algorithm code defined above; if the algorithm is not one of the pre-defined algorithms, 0 is returned.
+     */
+    @Override
+    public byte getAlgorithm() {
+        return algorithm;
+    }
+
+    /**
+     * Gets the raw cipher algorithm. Pre-defined codes listed in CIPHER_* constants in this class e.g. CIPHER_AES_CBC.
+     * @return the raw cipher algorithm code defined above; if the algorithm is not one of the pre-defined algorithms, 0 is returned.
+     */
+    @Override
+    public byte getCipherAlgorithm() {
+        switch(algorithm){
+            case ALG_AES_CCM:
+                return  CIPHER_AES_CCM;
+
+            case ALG_AES_GCM:
+                return CIPHER_AES_GCM;
+        }
+        return 0;
+    }
+
+    /**
+     * Gets the padding algorithm. Pre-defined codes listed in PAD_* constants in this class e.g. PAD_NULL.
+     * @return the padding algorithm code defined in the Cipher class; if the algorithm is not one of the pre-defined algorithms, 0 is returned.
+     */
+    @Override
+    public byte getPaddingAlgorithm() {
+        return 0;
+    }
+    /**
+     * Initializes the Cipher object with the appropriate Key.
+     * This method should be used for algorithms which do not need initialization parameters or use default parameter values.
+     * init() must be used to update the Cipher object with a new key.
+     * If the Key object is modified after invoking the init() method, the behavior of the update() and doFinal() methods is unspecified.
+     * The Key is checked for consistency with the Cipher algorithm. For example, the key type must be matched.
+     * For elliptic curve algorithms, the key must represent a valid point on the curve's domain parameters.
+     * Additional key component/domain parameter strength checks are implementation specific.
+     * Note:
+     *      <li>AES, DES, triple DES and Korean SEED algorithms in CBC mode will use 0 for initial vector(IV) if this method is used.</li>
+     *      <li>For optimal performance, when the theKey parameter is a transient key, the implementation should, whenever possible, use transient space for internal storage.</li>
+     *      <li>AEADCipher in GCM mode will use 0 for initial vector(IV) if this method is used.</li>
+     * @param theKey the key object to use for encrypting or decrypting
+     * @param theMode one of MODE_DECRYPT or MODE_ENCRYPT
+     * @throws CryptoException- with the following reason codes:
+     *      <li>CryptoException.ILLEGAL_VALUE if theMode option is an undefined value or
+     *      if the Key is inconsistent with the Cipher implementation.</li>
+     *      <li>CryptoException.UNINITIALIZED_KEY if theKey instance is uninitialized.</li>
+     *      <li>CryptoException.INVALID_INIT if this method is called for an offline mode of encryption</li>
+     */
+    @Override
+    public void init(Key theKey, byte theMode) throws CryptoException {
+        // Support only GCM which can operate in online mode
+        if (algorithm != ALG_AES_GCM) {
+            CryptoException.throwIt(CryptoException.INVALID_INIT);
+        }
+
+        if( (theMode != MODE_DECRYPT) && (theMode != MODE_ENCRYPT)){
+            CryptoException.throwIt(CryptoException.ILLEGAL_VALUE);
+        }
+
+        // AEADCipher in GCM mode will use 0 for initial vector(IV) if this method is used
+        byte[] iv = new byte[12];
+        Arrays.fill(iv, (byte) 0);
+
+        selectCipherEngine(theKey);
+
+        ParametersWithIV parametersWithIV = new ParametersWithIV(((SymmetricKeyImpl) theKey).getParameters(),iv);
+        try{
+            engine.init(theMode == MODE_ENCRYPT, parametersWithIV);
+        }
+        catch (Exception ex){
+            ex.printStackTrace();
+            CryptoException.throwIt(CryptoException.ILLEGAL_VALUE);
+        }
+
+        initMode = theMode;
+        state = CipherState.Initialized;
+    }
+
+    /**
+     * Initializes the Cipher object with the appropriate Key and algorithm specific parameters.
+     * init() must be used to update the Cipher object with a new key.
+     * If the Key object is modified after invoking the init() method, the behavior of the update() and doFinal() methods is unspecified.
+     *
+     * The Key is checked for consistency with the Cipher algorithm. For example, the key type must be matched.
+     * For elliptic curve algorithms, the key must represent a valid point on the curve's domain parameters.
+     * Additional key component/domain parameter strength checks are implementation specific.
+     *
+     * Note:
+     * <li>DES and triple DES algorithms in CBC mode expect an 8-byte parameter value for the initial vector(IV) in bArray.</li>
+     * <li>AES algorithms in CBC mode expect a 16-byte parameter value for the initial vector(IV) in bArray.</li>
+     * <li>Korean SEED algorithms in CBC mode expect a 16-byte parameter value for the initial vector(IV) in bArray.</li>
+     * <li>AES algorithms in ECB mode, DES algorithms in ECB mode, Korean SEED algorithm in ECB mode, RSA and DSA algorithms throw CryptoException.ILLEGAL_VALUE.</li>
+     * <li>For optimal performance, when the theKey parameter is a transient key, the implementation should, whenever possible, use transient space for internal storage.</li>
+     *
+     * @param theKey the key object to use for encrypting or decrypting.
+     * @param theMode one of MODE_DECRYPT or MODE_ENCRYPT
+     * @param bArray byte array containing algorithm specific initialization info
+     * @param bOff offset within bArray where the algorithm specific data begins
+     * @param bLen byte length of algorithm specific parameter data
+     * @throws CryptoException with the following reason codes:
+     *         <li>CryptoException.ILLEGAL_VALUE if theMode option is an undefined value or
+     *         if a byte array parameter option is not supported by the algorithm or
+     *         if the bLen is an incorrect byte length for the algorithm specific data or
+     *         if the Key is inconsistent with the Cipher implementation.</li>
+     *         <li>CryptoException.UNINITIALIZED_KEY if theKey instance is uninitialized.</li>
+     *         <li>CryptoException.INVALID_INIT if this method is called for an offline mode of encryption</li>
+     */
+    @Override
+    public void init(Key theKey, byte theMode, byte[] bArray, short bOff, short bLen) throws CryptoException {
+        // Support only GCM which can operate as an online mode of encryption
+        if (algorithm != ALG_AES_GCM){
+            CryptoException.throwIt(CryptoException.INVALID_INIT);
+        }
+
+        if( (theMode != MODE_DECRYPT) && (theMode != MODE_ENCRYPT)){
+            CryptoException.throwIt(CryptoException.ILLEGAL_VALUE);
+        }
+
+        // Supports only the 12 byte IV length, which is the value recommended by NIST Special Publication 800-38D 5.2.1.1 Input Data
+        // https://docs.oracle.com/javacard/3.0.5/guide/supported-cryptography-classes.htm#JCUGC356
+        if( bLen != 12 ){
+            CryptoException.throwIt(CryptoException.ILLEGAL_VALUE);
+        }
+
+        selectCipherEngine(theKey);
+        byte[] iv = JCSystem.makeTransientByteArray(bLen, JCSystem.CLEAR_ON_RESET);
+        Util.arrayCopyNonAtomic(bArray, bOff, iv, (short) 0, bLen);
+        ParametersWithIV parametersWithIV = new ParametersWithIV(((SymmetricKeyImpl) theKey).getParameters(),iv);
+        try{
+            engine.init(theMode == MODE_ENCRYPT, parametersWithIV);
+        }
+        catch (Exception ex){
+            ex.printStackTrace();
+            CryptoException.throwIt(CryptoException.ILLEGAL_VALUE);
+        }
+
+        initMode = theMode;
+        state = CipherState.Initialized;
+    }
+
+    /**
+     * Initializes this Cipher instance to encrypt or decrypt a with the given key, nonce, AAD size and message size.
+     * This method should only be called for offline cipher mode encryption such as Cipher#ALG_AES_CCM.
+     * In offline cipher mode encryption the length of the authentication data, message size and authentication tag must be known in advance.
+     *
+     * @see javacardx.crypto.AEADCipher#init(Key, byte, byte[], short, short, short, short, short)
+     * @param theKey the key object to use for encrypting or decrypting
+     * @param theMode one of MODE_DECRYPT or MODE_ENCRYPT
+     * @param nonceBuf a buffer holding the nonce
+     * @param nonceOff the offset in the buffer of the nonce
+     * @param nonceLen the length in the buffer of the nonce
+     * @param adataLen the length of the authenticated data as presented in the updateAAD method
+     * @param messageLen the length of the message as presented in the update and doFinal methods
+     * @param tagSize the size in bytes of the authentication tag
+     * @throws CryptoException with the following reason codes:
+     *         <li>CryptoException.ILLEGAL_VALUE if any of the values are outside the accepted range</li>
+     *         <li>CryptoException.UNINITIALIZED_KEY if theKey instance is uninitialized.</li>
+     *         <li>CryptoException.INVALID_INIT if this method is called for an online mode of encryption</li>
+     */
+    @Override
+    public void init(Key theKey, byte theMode, byte[] nonceBuf, short nonceOff, short nonceLen, short adataLen, short messageLen, short tagSize) throws CryptoException {
+        if( (theMode != MODE_DECRYPT) && (theMode != MODE_ENCRYPT)){
+            CryptoException.throwIt(CryptoException.ILLEGAL_VALUE);
+        }
+
+        // Check if this method is called for an online mode of encryption
+        if( (messageLen == 0) || (tagSize == 0) ){
+            CryptoException.throwIt(CryptoException.INVALID_INIT);
+        }
+
+        // Supports only the 12 byte IV length, which is the value recommended by NIST Special Publication 800-38D 5.2.1.1 Input Data
+        // https://docs.oracle.com/javacard/3.0.5/guide/supported-cryptography-classes.htm#JCUGC356
+        if( nonceLen != 12 ){
+            CryptoException.throwIt(CryptoException.ILLEGAL_VALUE);
+        }
+
+        selectCipherEngine(theKey);
+
+        byte[] iv_nonce = JCSystem.makeTransientByteArray(nonceLen, JCSystem.CLEAR_ON_RESET);
+        Util.arrayCopyNonAtomic(nonceBuf, nonceOff, iv_nonce, (short) 0, nonceLen);
+
+        parameters = new AEADParameters((KeyParameter) ((SymmetricKeyImpl) theKey).getParameters(),tagSize * Byte.SIZE, iv_nonce );
+
+        try{
+            engine.init(theMode == MODE_ENCRYPT, parameters);
+        }
+        catch (Exception ex){
+            ex.printStackTrace();
+            CryptoException.throwIt(CryptoException.ILLEGAL_VALUE);
+        }
+
+        initMode = theMode;
+        initMsgLen = messageLen;
+        initAADLen = adataLen;
+        totalMsgLen = 0;
+        state = CipherState.Initialized;
+    }
+
+    /**
+     * Continues a multi-part update of the Additional Associated Data (AAD) that will be verified by the authentication tag.
+     * The data is not included with the ciphertext by this method.
+     *
+     * @param aadBuf the buffer containing the AAD data
+     * @param aadOff the offset of the AAD data in the buffer
+     * @param aadLen the length in bytes of the AAD data in the buffer
+     * @throws CryptoException with the following reason codes:
+     *     <li>ILLEGAL_USE if updating the AAD value is conflicting with the state of this cipher</li>
+     *     <li>ILLEGAL_VALUE for CCM if the AAD size is different from the AAD size given in the initial block used as IV</li>
+     */
+    @Override
+    public void updateAAD(byte[] aadBuf, short aadOff, short aadLen) throws CryptoException {
+        if ( state == CipherState.Uninitialized ){
+            CryptoException.throwIt(CryptoException.ILLEGAL_USE);
+        }
+
+        if( algorithm == ALG_AES_CCM){
+           if( aadLen != initAADLen )
+               CryptoException.throwIt(CryptoException.ILLEGAL_VALUE);
+        }
+
+        engine.processAADBytes(aadBuf,aadOff,aadLen);
+    }
+
+    /**
+     * Generates encrypted/decrypted output from input data. This method is intended for multiple-part encryption/decryption operations.
+     * This method requires temporary storage of intermediate results.
+     * In addition, if the input data length is not block aligned (multiple of block size) then additional internal storage may be allocated at this time to store a partial input data block.
+     * This may result in additional resource consumption and/or slow performance.
+     *
+     * This method should only be used if all the input data required for the cipher is not available in one byte array.
+     * If all the input data required for the cipher is located in a single byte array, use of the doFinal() method to process all of the input data is recommended.
+     * The doFinal() method must be invoked to complete processing of any remaining input data buffered by one or more calls to the update() method.
+     * SensitiveResult class, if supported by the platform.
+     *
+     * @param inBuff the input buffer of data to be encrypted/decrypted
+     * @param inOffset the offset into the input buffer at which to begin encryption/decryption
+     * @param inLength the byte length to be encrypted/decrypted
+     * @param outBuff the output buffer, may be the same as the input buffer
+     * @param outOffset  the offset into the output buffer where the resulting ciphertext/plaintext begins
+     * @return number of bytes output in outBuff
+     * @throws CryptoException with the following reason codes:
+     *        <li>CryptoException.INVALID_INIT if this Cipher object is not initialized.</li>
+     *        <li>CryptoException.UNINITIALIZED_KEY if key not initialized.</li>
+     *        <li>CryptoException.ILLEGAL_USE</li>
+     *             <li>for CCM if AAD is not provided while it is indicated in the initial block used as IV</li>
+     *             <li>for CCM if the payload exceeds the payload size given in the initial block used as IV</li>
+     */
+    @Override
+    public short update(byte[] inBuff, short inOffset, short inLength, byte[] outBuff, short outOffset) throws CryptoException {
+        if (state == CipherState.Uninitialized) {
+            CryptoException.throwIt(CryptoException.INVALID_INIT);
+        }
+
+        int processBuffSize = engine.getUpdateOutputSize(inLength);
+
+        byte[] processBuff = new byte[processBuffSize];
+        short processedBytes = (short)engine.processBytes(inBuff, inOffset, inLength, processBuff, 0);
+        Util.arrayCopyNonAtomic(processBuff, (short) 0,outBuff,outOffset, processedBytes);
+
+        totalMsgLen += inLength;
+        return processedBytes;
+    }
+
+    /**
+     * Generates encrypted/decrypted output from all/last input data. This method must be invoked to complete a cipher operation.
+     * This method processes any remaining input data buffered by one or more calls to the update() method as well as input data supplied in the inBuff parameter.
+     * A call to this method also resets this Cipher object to the state it was in when previously initialized via a call to init().
+     * That is, the object is reset and available to encrypt or decrypt (depending on the operation mode that was specified in the call to init()) more data.
+     * In addition, note that the initial vector(IV) used in AES, DES and Korean SEED algorithms will be reset to 0.
+     *
+     * @param inBuff the input buffer of data to be encrypted/decrypted
+     * @param inOffset the offset into the input buffer at which to begin encryption/decryption
+     * @param inLength the byte length to be encrypted/decrypted
+     * @param outBuff the output buffer, may be the same as the input buffer
+     * @param outOffset the offset into the output buffer where the resulting output data begins
+     * @return number of bytes output in outBuff
+     * @throws CryptoException with the following reason codes:
+     *         <li>INVALID_INIT if this Cipher object is not initialized.</li>
+     *         <li>UNINITIALIZED_KEY if key not initialized.</li>
+     *         <li>ILLEGAL_USE</li>
+     *               <li>for CCM if all Additional Authenticated Data (AAD) was not provided</li>
+     *               <li>for CCM if the total message size provided is not identical to the messageLen parameter given in the init method</li>
+     */
+    @Override
+    public short doFinal(byte[] inBuff, short inOffset, short inLength, byte[] outBuff, short outOffset) throws CryptoException {
+        if (state == CipherState.Uninitialized) {
+            CryptoException.throwIt(CryptoException.INVALID_INIT);
+        }
+
+        if (algorithm == ALG_AES_CCM) {
+            if( engine.getMac().length == 0 ){
+                CryptoException.throwIt(CryptoException.ILLEGAL_USE);
+            }
+
+            totalMsgLen += inLength;
+            if( totalMsgLen != initMsgLen){
+                CryptoException.throwIt(CryptoException.ILLEGAL_USE);
+            }
+        }
+
+        int processBuffSize = engine.getOutputSize(inLength);
+        byte[] processBuff = new byte[processBuffSize];
+
+        try {
+            short processedBytes = (short) engine.processBytes(inBuff, inOffset, inLength, processBuff, 0);
+            processedBytes += engine.doFinal(processBuff, processedBytes);
+            Util.arrayCopyNonAtomic(processBuff, (short) 0,outBuff,outOffset, processedBytes);
+            state = CipherState.Finalized;
+            return processedBytes;
+
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            CryptoException.throwIt(CryptoException.ILLEGAL_USE);
+        }
+
+        return -1;
+
+    }
+
+    /**
+     * Retrieves tagLen bytes from the calculated authentication tag. Depending on the algorithm, only certain tag lengths may be supported.
+     * Note:
+     * This method may only be called for MODE_ENCRYPT after doFinal has been called.
+     * In addition to returning a short result, this method sets the result in an internal state which can be rechecked using assertion methods of the SensitiveResult class, if supported by the platform.
+     * @param tagBuf the buffer that will contain the authentication tag
+     * @param tagOff the offset of the authentication tag in the buffer
+     * @param tagLen the length in bytes of the authentication tag in the buffer
+     * @return the tag length, as given by tagLen (for convenience)
+     * @throws CryptoException with the following reason codes
+     *         <li>ILLEGAL_USE if doFinal has not been called</li>
+     *         <li>ILLEGAL_VALUE if the tag length is not supported</li>
+     */
+    @Override
+    public short retrieveTag(byte[] tagBuf, short tagOff, short tagLen) throws CryptoException {
+        if( state != CipherState.Finalized ){
+            CryptoException.throwIt(CryptoException.ILLEGAL_USE);
+        }
+
+        if( initMode != MODE_ENCRYPT){
+            CryptoException.throwIt(CryptoException.ILLEGAL_USE);
+        }
+
+        if( !checkSupportTagLength(tagLen)) {
+            CryptoException.throwIt(CryptoException.ILLEGAL_VALUE);
+        }
+
+        byte[] mac = engine.getMac();
+
+        Util.arrayCopyNonAtomic(mac, (short) 0,tagBuf, tagOff, tagLen);
+
+        return tagLen;
+    }
+
+    /**
+     * Verifies the authentication tag using the number of bits set in requiredTagLen bits.
+     * Depending on the algorithm, only certain tag lengths may be supported. For all algorithms the tag length must be a multiple of 8 bits.
+     * Note:
+     *     <li>This method may only be called for MODE_DECRYPT after doFinal has been called.</li>
+     * In addition to returning a boolean result, this method sets the result in an internal state which can be rechecked using assertion methods of the SensitiveResult class, if supported by the platform.
+     * @param receivedTagBuf the buffer that will contain the received authentication tag
+     * @param receivedTagOff the offset of the received authentication tag in the buffer
+     * @param receivedTagLen the length in bytes of the received authentication tag in the buffer
+     * @param requiredTagLen the required length in bytes of the received authentication tag, usually a constant value
+     * @return Tag verification result
+     * @throws CryptoException with the following reason codes:
+     *         <li>ILLEGAL_USE if doFinal has not been called</li>
+     *         <li>ILLEGAL_VALUE if the tag length is not supported</li>
+     */
+    @Override
+    public boolean verifyTag(byte[] receivedTagBuf, short receivedTagOff, short receivedTagLen, short requiredTagLen) throws CryptoException {
+        if( state != CipherState.Finalized ){
+            CryptoException.throwIt(CryptoException.ILLEGAL_USE);
+        }
+
+        if( initMode != MODE_DECRYPT){
+            CryptoException.throwIt(CryptoException.ILLEGAL_USE);
+        }
+        
+        if( !checkSupportTagLength(requiredTagLen)){
+            CryptoException.throwIt(CryptoException.ILLEGAL_VALUE);
+        }
+
+        byte[] mac = engine.getMac();
+        return Arrays.areEqual(mac,0,requiredTagLen,receivedTagBuf,receivedTagOff,receivedTagOff + receivedTagLen);
+    }
+
+    private void selectCipherEngine(Key theKey) {
+        if (theKey == null) {
+            CryptoException.throwIt(CryptoException.UNINITIALIZED_KEY);
+        }
+        if (!theKey.isInitialized()) {
+            CryptoException.throwIt(CryptoException.UNINITIALIZED_KEY);
+        }
+        if (!(theKey instanceof SymmetricKeyImpl)) {
+            CryptoException.throwIt(CryptoException.ILLEGAL_VALUE);
+        }
+
+        SymmetricKeyImpl key = (SymmetricKeyImpl) theKey;
+
+        switch (algorithm) {
+
+            case ALG_AES_CCM:
+                try{
+                    engine = new CCMBlockCipher(key.getCipher());
+                }
+                catch (Exception ex){
+                    ex.printStackTrace();
+                    CryptoException.throwIt(CryptoException.ILLEGAL_VALUE);
+                }
+                break;
+
+            case ALG_AES_GCM:
+                try{
+                    engine = new GCMBlockCipher(key.getCipher());
+                }
+                catch (Exception ex){
+                    ex.printStackTrace();
+                    CryptoException.throwIt(CryptoException.ILLEGAL_VALUE);
+                }
+                break;
+
+            default:
+                CryptoException.throwIt(CryptoException.NO_SUCH_ALGORITHM);
+                break;
+        }
+    }
+
+    private boolean checkSupportTagLength(short tagLen){
+        short tagLenInBits = (short) (tagLen * Byte.SIZE);
+
+        if( tagLenInBits == 128) return true;
+        if( tagLenInBits == 120) return true;
+        if( tagLenInBits == 112) return true;
+        if( tagLenInBits == 104) return true;
+        if( tagLenInBits == 96) return true;
+        if( tagLenInBits == 64) return true;
+        if( tagLenInBits == 32) return true;
+
+        return false;
+    }
+}

--- a/src/main/java/com/licel/jcardsim/crypto/CipherProxy.java
+++ b/src/main/java/com/licel/jcardsim/crypto/CipherProxy.java
@@ -44,7 +44,7 @@ public class CipherProxy {
         if (externalAccess) {
             CryptoException.throwIt((short) 3);
         }
-        System.out.println("CipherProxy");
+ 
         switch (algorithm) {
             case Cipher.ALG_DES_CBC_NOPAD:
             case Cipher.ALG_DES_CBC_ISO9797_M1:

--- a/src/main/java/com/licel/jcardsim/crypto/CipherProxy.java
+++ b/src/main/java/com/licel/jcardsim/crypto/CipherProxy.java
@@ -17,6 +17,7 @@ package com.licel.jcardsim.crypto;
 
 import javacard.security.CryptoException;
 import javacardx.crypto.Cipher;
+import javacardx.crypto.AEADCipher;
 /**
  * ProxyClass for <code>Cipher</code>
  * @see Cipher
@@ -43,6 +44,7 @@ public class CipherProxy {
         if (externalAccess) {
             CryptoException.throwIt((short) 3);
         }
+        System.out.println("CipherProxy");
         switch (algorithm) {
             case Cipher.ALG_DES_CBC_NOPAD:
             case Cipher.ALG_DES_CBC_ISO9797_M1:
@@ -64,6 +66,11 @@ public class CipherProxy {
             case Cipher.ALG_RSA_PKCS1_OAEP:
                 instance = new AsymmetricCipherImpl(algorithm);
                 break;
+            case AEADCipher.ALG_AES_GCM:
+            case AEADCipher.ALG_AES_CCM:
+                instance = new AuthenticatedSymmetricCipherImpl(algorithm);
+                break;
+
             default:
                 CryptoException.throwIt(CryptoException.NO_SUCH_ALGORITHM);
                 break;

--- a/src/test/java/com/licel/jcardsim/crypto/AuthenticatedSymmetricCipherImplTest.java
+++ b/src/test/java/com/licel/jcardsim/crypto/AuthenticatedSymmetricCipherImplTest.java
@@ -1,0 +1,740 @@
+/*
+ * Copyright 2022 Licel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.licel.jcardsim.crypto;
+
+import javacard.security.*;
+import javacardx.crypto.AEADCipher;
+import javacardx.crypto.Cipher;
+import junit.framework.TestCase;
+import org.bouncycastle.util.Arrays;
+import org.bouncycastle.util.encoders.Hex;
+
+import java.util.Random;
+
+public class AuthenticatedSymmetricCipherImplTest extends TestCase {
+    public AuthenticatedSymmetricCipherImplTest(String testName) {
+        super(testName);
+    }
+
+    protected void setUp() throws Exception {
+        super.setUp();
+    }
+
+    protected void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    public void testAES_GCM_NotSupportKey(){
+        byte[] desKey64bit = new byte[KeyBuilder.LENGTH_DES/Byte.SIZE];
+        new Random().nextBytes(desKey64bit);
+
+        // AEAD ciphers can be created by the Cipher.getInstance method using the ALG_AES_GCM and ALG_AES_CCM algorithm constants.
+        // The returned Cipher instance should then be cast to AEADCipher.
+        AEADCipher engine = (AEADCipher) Cipher.getInstance(AEADCipher.ALG_AES_GCM, false);
+
+        DESKey desKey = (DESKey) KeyBuilder.buildKey(KeyBuilder.TYPE_DES, KeyBuilder.LENGTH_DES, false);
+        desKey.setKey(desKey64bit, (short) 0);
+
+        try {
+            engine.init(desKey, Cipher.MODE_ENCRYPT);
+            fail("No exception");
+        }
+        catch (CryptoException e) {
+            assertEquals(CryptoException.ILLEGAL_VALUE, e.getReason());
+        }
+    }
+
+
+
+    // GCM sample test data downloaded from NIST.GOV
+    // https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/mac/gcmtestvectors.zip
+    public void testAES_GCM_Sample_Key128Bit_AAD128Bit_Tag128Bit(){
+        String[] testData = {
+                "298efa1ccf29cf62ae6824bfc19557fc",                                 // 128-bit Key
+                "6f58a93fe1d207fae4ed2f6d",                                         // 96-bit IV
+                "cc38bccd6bc536ad919b1395f5d63801f99f8068d65ca5ac63872daf16b93901", // 256-bit PT  (Plain Text)
+                "021fafd238463973ffe80256e5b1c6b1",                                 // 128-bit AAD (Additional Authenticated Data)
+                "dfce4e9cd291103d7fe4e63351d9e79d3dfd391e3267104658212da96521b7db", // 256-bit CT (Cipher Text)
+                "542465ef599316f73a7a560509a2d9f2"                                  // 128-bit Tag
+        };
+
+        testAES_GCM_PrearrangedResult(testData);
+    }
+
+    public void testAES_GCM_Sample_Key128Bit_NoAAD_Tag96Bit(){
+        String[] testData = {
+                "82ba8dc240bc3e5ea1c98ae5c8bc58a3",                                 // 128-bit Key
+                "a016b0b2ab3e259f738ba228",                                         // 96-bit IV
+                "42f6d57361d1afc1558ff23bd333b6adfa7fd622c436b27513c6391174a72473", // 256-bit PT  (Plain Text)
+                "",
+                "b7ea8f84d5b05f23d71678c4e546306d53703a25043cd7102579bac8cdd9bc4e", // 256-bit CT (Cipher Text)
+                "796964243c22d258fa4fc4f4"                                          // 96-bit Tag
+        };
+
+        testAES_GCM_PrearrangedResult(testData);
+    }
+
+    public void testAES_GCM_Sample_Key128Bit_AAD128Bit_ShortTag64Bit(){
+        String[] testData = {
+                "76faaf2bfbd103b5fae725f4990b8282",                                 // 128-bit Key
+                "4f32472c588fcbae5012ce70",                                         // 96-bit IV
+                "58be7470b3b0de22a8f902fda1100215b56831805920be92a7e57d81c150acba", // 256-bit PT  (Plain Text)
+                "6e4141d7f79d4e2682cd605e3e39033c",                                 // 128-bit AAD (Additional Authenticated Data)
+                "11e3c43c549d277e42feb0d2ef39715ac8d86bd925ed7e64f17b97688daeef8b", // 256-bit CT (Cipher Text)
+                "37d7c65a03635f8d"                                                  // 64-bit Tag
+        };
+
+        testAES_GCM_PrearrangedResult(testData);
+    }
+
+    public void testAES_GCM_Sample_Key192Bit_AAD128Bit_Tag112Bit(){
+        String[] testData = {
+                "8ef391e4b7a2fe05b959be27823357080f963ed2f64b9e59",    // 192-bit Key
+                "0080052a2a5bb0e95222a419",                            // 96-bit IV
+                "e7fb0631eebf9bdba87045b33650c4ce",                    // 128-bit PT  (Plain Text)
+                "290322092d57479e20f6281e331d95a9",                    // 128-bit AAD (Additional Authenticated Data)
+                "88d674044031414af7ba9da8b89dd68e",                    // 256-bit CT (Cipher Text)
+                "69897d99d8e1706f38c613896c18"                         // 64-bit Tag
+        };
+
+        testAES_GCM_PrearrangedResult(testData);
+    }
+
+    public void testAES_GCM_Sample_Key192Bit_AAD160Bit_Tag128Bit() {
+        String[] testData = {
+                "95e5c8dcee4ef17571e1becc3f2d4ac8d5aa73e74b3f1115",    // 192-bit Key
+                "e3b91649120f92b4f712644b",                            // 96-bit IV
+                "eca3606b9e2a0c7a1c6c4b765176f643",                    // 128-bit PT  (Plain Text)
+                "68b093733bd1e77448fe5687b74796834d1797cf",            // 160-bit AAD (Additional Authenticated Data)
+                "0ff6d858cf0f5309c0f4b2747f6b551f",                    // 128-bit CT (Cipher Text)
+                "94d6ac2796a9b9901933a0f9e5377979"                     // 128-bit Tag
+        };
+
+        testAES_GCM_PrearrangedResult(testData);
+    }
+
+    public void testAES_GCM_NotSupportTagLength() {
+
+        byte[] key128Bit = new byte[128/Byte.SIZE];
+        new Random().nextBytes(key128Bit);
+
+        byte[] iv96Bit = new byte[96/Byte.SIZE];
+        new Random().nextBytes(iv96Bit);
+
+        AEADCipher engine = (AEADCipher) Cipher.getInstance(AEADCipher.ALG_AES_GCM, false);
+
+        short keyInBitSize = (short) (key128Bit.length * 8);
+        AESKey aesKey = (AESKey) KeyBuilder.buildKey(KeyBuilder.TYPE_AES, KeyBuilder.LENGTH_AES_128, false);
+        aesKey.setKey(key128Bit, (short) 0);
+
+        final short AAD_BYTES = 32;
+        final short MSG_BYTES = 32;
+        final short NOT_SUPPORT_TAG_LEN = 32;
+        try {
+            engine.init(aesKey, Cipher.MODE_ENCRYPT,iv96Bit,(short)0,(short)iv96Bit.length, AAD_BYTES, MSG_BYTES, NOT_SUPPORT_TAG_LEN);
+            fail("No exception");
+        }
+        catch (CryptoException e) {
+            assertEquals(CryptoException.ILLEGAL_VALUE, e.getReason());
+        }
+
+    }
+
+    public void testAES_GCM_Key256Bit_AAD128Bit_Tag120Bit(){
+        String[] testData = {
+                // 256-bit Key
+                "8bdb9073bca042d3bfe99240c438386c877d2a00b1f3bc9485aea034982b6779",
+
+                // 96-bit IV
+                "b2d1c505266a5b2eb32faa44",
+
+                // 408-bit PT  (Plain Text)
+                "1140acb00c1a37dffeead3f47b9c37b4140b7dd1965a8fbba76bcf7614b03398eb777f598bdd2599959a5b0ee6e1af75838888",
+
+                // 160-bit AAD (Additional Authenticated Data)
+                "182188be275f93fb909f61eba148fb62",
+
+                // 408-bit CT  (Cipher Text)
+                "1f99d4b40f9a9a5494d87215b447f2e7cbcaf6a141b12a9b2210ae9e8a99776b03346596adabc5872b7113d8099366a3e7bd36",
+
+                // 120-bit Tag
+                "3a4ca34a8b63e78a4405288a9b2738"
+        };
+
+        testAES_GCM_PrearrangedResult(testData);
+    }
+
+    public void testAES_GCM_PrearrangedResult(String[] testData){
+        byte[] key = Hex.decode(testData[0]);
+        byte[] iv = Hex.decode(testData[1]);
+        byte[] plaintext = Hex.decode(testData[2]);
+        byte[] aad = Hex.decode(testData[3]);
+        byte[] ciphertext = Hex.decode(testData[4]);
+        byte[] tag = Hex.decode(testData[5]);
+
+        short keyInBitSize = (short) (key.length * 8);
+        AESKey aesKey = (AESKey) KeyBuilder.buildKey(KeyBuilder.TYPE_AES_TRANSIENT_RESET, keyInBitSize, false);
+        aesKey.setKey(key, (short) 0);
+
+        AEADCipher engine = (AEADCipher) Cipher.getInstance(AEADCipher.ALG_AES_GCM, false);
+
+        // Test encryption
+        engine.init(aesKey, Cipher.MODE_ENCRYPT,iv,(short)0,(short)iv.length, (short) aad.length, (short) plaintext.length, (short) tag.length);
+        engine.updateAAD(aad, (short) 0, (short) aad.length);
+
+        byte[] encrypted = new byte[plaintext.length + tag.length];
+        short encryptProcessedBytes = engine.doFinal(plaintext, (short) 0, (short) plaintext.length,encrypted, (short) 0);
+
+        assertEquals(true,Arrays.areEqual(ciphertext,0,ciphertext.length,encrypted,0,ciphertext.length));
+        assertEquals( encryptProcessedBytes, encrypted.length);
+
+        byte[] retrievedTag = new byte[tag.length];
+        engine.retrieveTag(retrievedTag, (short) 0, (short) retrievedTag.length);
+
+        assertEquals(true, Arrays.areEqual(retrievedTag, tag));
+
+        // Test decryption with wrong AAD
+        byte[] wrongAAD = new byte[16];
+        new Random().nextBytes(wrongAAD);
+
+        engine.init(aesKey, Cipher.MODE_DECRYPT,iv,(short)0,(short)iv.length, (short) wrongAAD.length, (short) ciphertext.length, (short) tag.length);
+        engine.updateAAD(wrongAAD, (short) 0, (short) wrongAAD.length);
+        byte[] decrypted = new byte[ciphertext.length];
+
+        short decryptProcessedBytes = 0;
+        try {
+            decryptProcessedBytes = engine.doFinal(encrypted, (short) 0, (short) (encrypted.length),decrypted, (short) 0);
+            fail("No exception");
+        }
+        catch (CryptoException e) {
+            assertEquals(CryptoException.ILLEGAL_USE, e.getReason());
+        }
+
+        // Re-initiate to reset cipher
+        engine.init(aesKey, Cipher.MODE_DECRYPT,iv,(short)0,(short)iv.length, (short) aad.length, (short) ciphertext.length, (short) tag.length);
+        engine.updateAAD(aad, (short) 0, (short) aad.length);
+
+        decryptProcessedBytes = engine.doFinal(encrypted, (short) 0, (short) (encrypted.length),decrypted, (short) 0);
+        assertEquals( decryptProcessedBytes, decrypted.length);
+
+        assertEquals(true, Arrays.areEqual(decrypted, plaintext));
+        assertEquals(true, engine.verifyTag(encrypted, (short) ciphertext.length, (short) tag.length, (short) tag.length));
+
+    }
+
+    public void testAES_GCM_SinglePartOfflineEncryptAndDecrypt(){
+        byte[] key256Bit = new byte[256/Byte.SIZE];
+        new Random().nextBytes(key256Bit);
+
+        byte[] iv96Bit = new byte[96/Byte.SIZE];
+        new Random().nextBytes(iv96Bit);
+
+        byte[] aad128Bit = new byte[128/Byte.SIZE];
+        new Random().nextBytes(aad128Bit);
+
+        String msg =
+                "Copyright 2022 Licel Corporation.\n" +
+                "Licensed under the Apache License, Version 2.0 (the \"License\");\n" +
+                "you may not use this file except in compliance with the License.\n" +
+                "You may obtain a copy of the License at\n" +
+                "\n" +
+                "      http://www.apache.org/licenses/LICENSE-2.0\n" +
+                "\n" +
+                "Unless required by applicable law or agreed to in writing, software\n" +
+                "distributed under the License is distributed on an \"AS IS\" BASIS,\n" +
+                "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n" +
+                "See the License for the specific language governing permissions and\n" +
+                "limitations under the License.\n";
+
+        byte[] msgBytes = msg.getBytes();
+
+        AESKey aesKey = (AESKey) KeyBuilder.buildKey(KeyBuilder.TYPE_AES, KeyBuilder.LENGTH_AES_256, false);
+        aesKey.setKey(key256Bit, (short) 0);
+
+        AEADCipher engine = (AEADCipher) Cipher.getInstance(AEADCipher.ALG_AES_GCM, false);
+
+        final short tagLenInBits = 96;
+        byte[] tag = new byte[tagLenInBits/Byte.SIZE];
+
+        // Test encryption
+        engine.init(aesKey, Cipher.MODE_ENCRYPT,iv96Bit,(short)0,(short)iv96Bit.length, (short) aad128Bit.length, (short) msgBytes.length, (short) tag.length);
+        engine.updateAAD(aad128Bit, (short) 0, (short) aad128Bit.length);
+
+        byte[] encrypted = new byte[msgBytes.length + tag.length];
+        short encryptProcessedBytes = engine.doFinal(msgBytes, (short) 0, (short) msgBytes.length,encrypted, (short) 0);
+        assertEquals( encryptProcessedBytes, encrypted.length);
+
+        engine.retrieveTag(tag, (short) 0, (short) tag.length);
+
+        // Decrypt back
+        engine.init(aesKey, Cipher.MODE_DECRYPT,iv96Bit,(short)0,(short)iv96Bit.length, (short) aad128Bit.length, (short) encrypted.length, (short) tag.length);
+        engine.updateAAD(aad128Bit, (short) 0, (short) aad128Bit.length);
+
+        byte[] decrypted = new byte[msgBytes.length];
+        short decryptProcessedBytes = engine.doFinal(encrypted, (short) 0, (short) (encrypted.length),decrypted, (short) 0);
+
+        assertEquals( decryptProcessedBytes, decrypted.length);
+        assertEquals(true, Arrays.areEqual(decrypted, msgBytes));
+        assertEquals(true, engine.verifyTag(tag, (short) 0, (short) tag.length, (short)(tagLenInBits/Byte.SIZE)));
+    }
+
+    public void testAES_GCM_MultiplePartOfflineEncryptAndDecrypt(){
+        byte[] key256Bit = new byte[256/Byte.SIZE];
+        new Random().nextBytes(key256Bit);
+
+        byte[] iv96Bit = new byte[96/Byte.SIZE];
+        new Random().nextBytes(iv96Bit);
+
+        byte[] aad128Bit = new byte[128/Byte.SIZE];
+        new Random().nextBytes(aad128Bit);
+
+        String msgPart1 =
+                "Copyright 2022 Licel Corporation.\n" +
+                "Licensed under the Apache License, Version 2.0 (the \"License\");\n" +
+                "you may not use this file except in compliance with the License.\n" +
+                "You may obtain a copy of the License at\n" +
+                "\n" +
+                "      http://www.apache.org/licenses/LICENSE-2.0\n" +
+                "\n";
+
+        String msgPart2 =
+                "Unless required by applicable law or agreed to in writing, software\n" +
+                "distributed under the License is distributed on an \"AS IS\" BASIS,\n" +
+                "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n" +
+                "See the License for the specific language governing permissions and\n" +
+                "limitations under the License.\n";
+
+
+        AESKey aesKey = (AESKey) KeyBuilder.buildKey(KeyBuilder.TYPE_AES, KeyBuilder.LENGTH_AES_256, false);
+        aesKey.setKey(key256Bit, (short) 0);
+
+        AEADCipher engine = (AEADCipher) Cipher.getInstance(AEADCipher.ALG_AES_GCM, false);
+
+        final short tagLenInBits = 96;
+        byte[] tag = new byte[tagLenInBits/Byte.SIZE];
+
+        short totalMsgLen = (short)( msgPart1.length() + msgPart2.length());
+        // Test encryption
+        engine.init(aesKey, Cipher.MODE_ENCRYPT,iv96Bit,(short)0,(short)iv96Bit.length, (short) aad128Bit.length, totalMsgLen, (short) tag.length);
+        engine.updateAAD(aad128Bit, (short) 0, (short) aad128Bit.length);
+
+        byte[] encrypted = new byte[totalMsgLen + tag.length ];
+
+        short encryptProcessedBytes = engine.update( msgPart1.getBytes(),(short) 0, (short) msgPart1.length(),encrypted,(short) 0);
+        encryptProcessedBytes += engine.doFinal(msgPart2.getBytes(), (short) 0, (short) msgPart2.length(),encrypted, (short) encryptProcessedBytes);
+        assertEquals( encryptProcessedBytes, encrypted.length);
+
+        engine.retrieveTag(tag, (short) 0, (short) tag.length);
+
+        // Decrypt back
+        engine.init(aesKey, Cipher.MODE_DECRYPT,iv96Bit,(short)0,(short)iv96Bit.length, (short) aad128Bit.length, (short)encrypted.length, (short) tag.length);
+        engine.updateAAD(aad128Bit, (short) 0, (short) aad128Bit.length);
+
+        byte[] decrypted = new byte[totalMsgLen];
+        short decryptProcessedBytes = engine.doFinal(encrypted, (short) 0, (short) (encrypted.length),decrypted, (short) 0);
+
+        assertEquals( decryptProcessedBytes, decrypted.length);
+        assertEquals(true, Arrays.areEqual(decrypted, 0, msgPart1.length(), msgPart1.getBytes(), 0, msgPart1.length()));
+        assertEquals(true, Arrays.areEqual(decrypted, msgPart1.length(), decrypted.length, msgPart2.getBytes(), 0, msgPart2.length()));
+        assertEquals(true, engine.verifyTag(tag, (short) 0, (short) tag.length, (short)(tagLenInBits/Byte.SIZE)));
+    }
+
+    public void testAES_GCM_OnlineEncryptAndDecryptWithZeroIV(){
+        byte[] key256Bit = new byte[256/Byte.SIZE];
+        new Random().nextBytes(key256Bit);
+
+        byte[] aad128Bit = new byte[128/Byte.SIZE];
+        new Random().nextBytes(aad128Bit);
+
+        AESKey aesKey = (AESKey) KeyBuilder.buildKey(KeyBuilder.TYPE_AES, KeyBuilder.LENGTH_AES_256, false);
+        aesKey.setKey(key256Bit, (short) 0);
+
+        AEADCipher engine = (AEADCipher) Cipher.getInstance(AEADCipher.ALG_AES_GCM, false);
+        engine.init(aesKey,Cipher.MODE_ENCRYPT);
+        engine.updateAAD(aad128Bit, (short) 0, (short) aad128Bit.length);
+
+        String msgPart1 =
+                "Copyright 2022 Licel Corporation.\n" +
+                "Licensed under the Apache License, Version 2.0 (the \"License\");\n" +
+                "you may not use this file except in compliance with the License.\n" +
+                "You may obtain a copy of the License at\n" +
+                "\n" +
+                "      http://www.apache.org/licenses/LICENSE-2.0\n" +
+                "\n";
+
+        String msgPart2 =
+                "Unless required by applicable law or agreed to in writing, software\n" +
+                "distributed under the License is distributed on an \"AS IS\" BASIS,\n" +
+                "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n" +
+                "See the License for the specific language governing permissions and\n" +
+                "limitations under the License.\n";
+
+        final short TAG_SIZE = 16;
+        byte[] encrypted = new byte[msgPart1.length() + msgPart2.length() + TAG_SIZE];
+        short encryptProcessedBytes = engine.update( msgPart1.getBytes(),(short) 0, (short) msgPart1.length(),encrypted,(short) 0);
+        encryptProcessedBytes += engine.doFinal(msgPart2.getBytes(), (short) 0, (short) msgPart2.length(),encrypted, encryptProcessedBytes);
+        assertEquals( encryptProcessedBytes, encrypted.length);
+
+        byte[] tag = new byte[encryptProcessedBytes - (msgPart1.length() + msgPart2.length())];
+        engine.retrieveTag(tag, (short) 0, (short) tag.length);
+
+        // Decrypt back
+        engine.init(aesKey, Cipher.MODE_DECRYPT);
+        engine.updateAAD(aad128Bit, (short) 0, (short) aad128Bit.length);
+
+        byte[] decrypted = new byte[msgPart1.length()+msgPart2.length()];
+        short decryptProcessedBytes = engine.doFinal(encrypted, (short) 0, (short) (encrypted.length),decrypted, (short) 0);
+
+        assertEquals( decryptProcessedBytes, decrypted.length);
+        assertEquals(true, Arrays.areEqual(decrypted, 0, msgPart1.length(), msgPart1.getBytes(), 0, msgPart1.length()));
+        assertEquals(true, Arrays.areEqual(decrypted, msgPart1.length(), decrypted.length, msgPart2.getBytes(), 0, msgPart2.length()));
+        assertEquals(true, engine.verifyTag(tag, (short) 0, (short) tag.length, TAG_SIZE));
+    }
+
+    public void testAES_GCM_OnlineEncryptAndDecryptWithIV(){
+        byte[] key256Bit = new byte[256 / Byte.SIZE];
+        new Random().nextBytes(key256Bit);
+
+        byte[] aad128Bit = new byte[128 / Byte.SIZE];
+        new Random().nextBytes(aad128Bit);
+
+        byte[] iv96Bit = new byte[96 / Byte.SIZE];
+        new Random().nextBytes(iv96Bit);
+
+        AESKey aesKey = (AESKey) KeyBuilder.buildKey(KeyBuilder.TYPE_AES, KeyBuilder.LENGTH_AES_256, false);
+        aesKey.setKey(key256Bit, (short) 0);
+
+        AEADCipher engine = (AEADCipher) Cipher.getInstance(AEADCipher.ALG_AES_GCM, false);
+        engine.init(aesKey, Cipher.MODE_ENCRYPT, iv96Bit, (short) 0, (short) iv96Bit.length);
+        engine.updateAAD(aad128Bit, (short) 0, (short) aad128Bit.length);
+
+        String msgPart1 =
+                "Copyright 2022 Licel Corporation.\n" +
+                "Licensed under the Apache License, Version 2.0 (the \"License\");\n" +
+                "you may not use this file except in compliance with the License.\n" +
+                "You may obtain a copy of the License at\n" +
+                "\n" +
+                "      http://www.apache.org/licenses/LICENSE-2.0\n" +
+                "\n";
+
+        String msgPart2 =
+                "Unless required by applicable law or agreed to in writing, software\n" +
+                "distributed under the License is distributed on an \"AS IS\" BASIS,\n" +
+                "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n" +
+                "See the License for the specific language governing permissions and\n" +
+                "limitations under the License.\n";
+
+        byte[] encrypted = new byte[msgPart1.length() + msgPart2.length() + aad128Bit.length];
+        short encryptProcessedBytes = engine.update(msgPart1.getBytes(), (short) 0, (short) msgPart1.length(), encrypted, (short) 0);
+        encryptProcessedBytes += engine.doFinal(msgPart2.getBytes(), (short) 0, (short) msgPart2.length(), encrypted, (short) encryptProcessedBytes);
+        assertEquals(encryptProcessedBytes, encrypted.length);
+
+        byte[] tag = new byte[encryptProcessedBytes - (msgPart1.length() + msgPart2.length())];
+        engine.retrieveTag(tag, (short) 0, (short) tag.length);
+
+        // Decrypt back
+        engine.init(aesKey, Cipher.MODE_DECRYPT,iv96Bit, (short) 0, (short) iv96Bit.length);
+        engine.updateAAD(aad128Bit, (short) 0, (short) aad128Bit.length);
+
+        byte[] decrypted = new byte[msgPart1.length() + msgPart2.length()];
+        short decryptProcessedBytes = engine.doFinal(encrypted, (short) 0, (short) (encrypted.length), decrypted, (short) 0);
+
+        assertEquals(decryptProcessedBytes, decrypted.length);
+        assertEquals(true, Arrays.areEqual(decrypted, 0, msgPart1.length(), msgPart1.getBytes(), 0, msgPart1.length()));
+        assertEquals(true, Arrays.areEqual(decrypted, msgPart1.length(), decrypted.length, msgPart2.getBytes(), 0, msgPart2.length()));
+        assertEquals(true, engine.verifyTag(tag, (short) 0, (short) tag.length, (short) aad128Bit.length));
+    }
+
+    public void testAES_CCM_NotSupportOnlineEncryption(){
+        byte[] key128bit = new byte[KeyBuilder.LENGTH_AES_128/Byte.SIZE];
+        new Random().nextBytes(key128bit);
+
+        AEADCipher engine = (AEADCipher) Cipher.getInstance(AEADCipher.ALG_AES_CCM, false);
+
+        AESKey aesKey = (AESKey) KeyBuilder.buildKey(KeyBuilder.TYPE_AES, KeyBuilder.LENGTH_AES_128, false);
+        aesKey.setKey(key128bit, (short) 0);
+
+        try {
+            // Call for online mode of encryption
+            engine.init(aesKey, Cipher.MODE_ENCRYPT);
+            fail("No exception");
+        }
+        catch (CryptoException e) {
+            assertEquals(CryptoException.INVALID_INIT, e.getReason());
+        }
+    }
+
+    // Use C.1 Example 1 in Appendix C of NIST Special Publication 800-38D
+    // https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38c.pdf
+    // Supports only the 12 byte IV length, which is the value recommended by NIST Special Publication 800-38D 5.2.1.1 Input Data
+    // https://docs.oracle.com/javacard/3.0.5/guide/supported-cryptography-classes.htm#JCUGC356
+    public void testAES_CCM_Sample_Key128Bit_AAD64Bit_Tag32Bit_NotSupportNonce56Bit() {
+        //In the following example, Klen = 128, Tlen=32, Nlen = 56, Alen = 64, and Plen = 32.
+        String[] testData = {
+                "40414243 44454647 48494a4b 4c4d4e4f",// Key
+                "20212223",//Payload
+                "00010203 04050607", //AAD
+                "10111213 141516", //Nonce
+                "7162015b 4dac255d", //Cipher text
+                "6084341b" // 32-bit tag
+
+        };
+
+        byte[] key = Hex.decode(testData[0]);
+        byte[] payload = Hex.decode(testData[1]);
+        byte[] aad = Hex.decode(testData[2]);
+        byte[] nonce = Hex.decode(testData[3]);
+        byte[] ciphertext = Hex.decode(testData[4]);
+
+        final short TAG_LEN = 4;
+
+        AESKey aesKey = (AESKey) KeyBuilder.buildKey(KeyBuilder.TYPE_AES, KeyBuilder.LENGTH_AES_128, false);
+        aesKey.setKey(key, (short) 0);
+
+        // AEAD ciphers can be created by the Cipher.getInstance method using the ALG_AES_GCM and ALG_AES_CCM algorithm constants.
+        // The returned Cipher instance should then be cast to AEADCipher.
+        AEADCipher engine = (AEADCipher) Cipher.getInstance(AEADCipher.ALG_AES_CCM, false);
+        try{
+            engine.init(aesKey, Cipher.MODE_ENCRYPT, nonce, (short) 0, (short) nonce.length, (short) aad.length, (short) payload.length, TAG_LEN);
+            fail("No exception");
+        }
+        catch (CryptoException e) {
+            assertEquals(CryptoException.ILLEGAL_VALUE, e.getReason());
+        }
+
+    }
+
+    // Use C.3 Example 3 in Appendix C of NIST Special Publication 800-38D
+    // https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38c.pdf
+    public void testAES_CCM_Sample_Key128Bit_AAD160Bit_Tag64Bit() {
+        //In the following example, Klen = 128, Tlen=64, Nlen = 96, Alen = 160, and Plen = 192.
+        String[] testData = {
+                "40414243 44454647 48494a4b 4c4d4e4f",// Key
+                "20212223 24252627 28292a2b 2c2d2e2f 30313233 34353637",//Payload
+                "00010203 04050607 08090a0b 0c0d0e0f 10111213", //AAD
+                "10111213 14151617 18191a1b", //Nonce
+                "e3b201a9 f5b71a7a 9b1ceaec cd97e70b 6176aad9 a4428aa5 484392fb c1b09951", //Cipher text
+                "67c99240 c7d51048" // 64-bit tag
+
+        };
+        final short TAG_LEN = 8;
+        testAES_CCM_PrearrangedResult(testData,TAG_LEN);
+    }
+
+    // Use sample vector from
+    // https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/mac/ccmtestvectors.zip
+    public void testAES_CCM_Sample_Key128Bit_AAD128Bit_Tag128Bit() {
+        String[] testData = {
+                "005e8f4d8e0cbf4e1ceeb5d87a275848",// 128-bit Key
+                "b6f345204526439daf84998f380dcfb4b4167c959c04ff65",// 24-byte Payload
+                "2f1821aa57e5278ffd33c17d46615b77363149dbc98470413f6543a6b749f2ca", // 32-byte AAD
+                "0ec3ac452b547b9062aac8fa", // 96-bit Nonce
+                "9575e16f35da3c88a19c26a7b762044f4d7bbbafeff05d754829e2a7752fa3a14890972884b511d8", // 192-bit Cipher text
+        };
+        final short TAG_LEN = 16;
+        testAES_CCM_PrearrangedResult(testData,TAG_LEN);
+    }
+
+    public void testAES_CCM_Sample_Key192Bit_AAD256Bit_Tag128Bit() {
+        String[] testData = {
+                "d49b255aed8be1c02eb6d8ae2bac6dcd7901f1f61df3bbf5",// 192-bit Key
+                "fc375d984fa13af4a5a7516f3434365cd9473cd316e8964c",// Payload
+                "4efbd225553b541c3f53cabe8a1ac03845b0e846c8616b3ea2cc7d50d344340c", // AAD
+                "ca650ed993c4010c1b0bd1f2", // 96-bit Nonce
+                "5b300c718d5a64f537f6cbb4d212d0f903b547ab4b21af56ef7662525021c5777c2d74ea239a4c44", //Cipher text
+        };
+        final short TAG_LEN = 16;
+        testAES_CCM_PrearrangedResult(testData,TAG_LEN);
+    }
+
+    public void testAES_CCM_Sample_Key256Bit_AAD256Bit_Tag128Bit() {
+        String[] testData = {
+                "d6ff67379a2ead2ca87aa4f29536258f9fb9fc2e91b0ed18e7b9f5df332dd1dc",// 256-bit Key
+                "98626ffc6c44f13c964e7fcb7d16e988990d6d063d012d33",// Payload
+                "d50741d34c8564d92f396b97be782923ff3c855ea9757bde419f632c83997630", // AAD
+                "2f1d0717a822e20c7cd28f0a", // 96-bit Nonce
+                "50e22db70ac2bab6d6af7059c90d00fbf0fb52eee5eb650e08aca7dec636170f481dcb9fefb85c05", //Cipher text
+        };
+        final short TAG_LEN = 16;
+        testAES_CCM_PrearrangedResult(testData,TAG_LEN);
+    }
+    private void testAES_CCM_PrearrangedResult(String[] testData, short tagLen){
+
+        byte[] key = Hex.decode(testData[0]);
+        byte[] payload = Hex.decode(testData[1]);
+        byte[] aad = Hex.decode(testData[2]);
+        byte[] nonce = Hex.decode(testData[3]);
+        byte[] ciphertext = Hex.decode(testData[4]);
+
+        boolean have_sample_tag = (testData.length == 6);
+        byte[] sample_tag = new byte[tagLen];
+        if( have_sample_tag ){
+            sample_tag = Arrays.copyOf(Hex.decode(testData[5]),tagLen);
+        }
+
+        AESKey aesKey = (AESKey) KeyBuilder.buildKey(KeyBuilder.TYPE_AES, (short) (key.length*Byte.SIZE), false);
+        aesKey.setKey(key, (short) 0);
+
+        // AEAD ciphers can be created by the Cipher.getInstance method using the ALG_AES_GCM and ALG_AES_CCM algorithm constants.
+        // The returned Cipher instance should then be cast to AEADCipher.
+        AEADCipher engine = (AEADCipher) Cipher.getInstance(AEADCipher.ALG_AES_CCM, false);
+        engine.init(aesKey, Cipher.MODE_ENCRYPT, nonce, (short) 0, (short) nonce.length, (short) aad.length, (short) payload.length, tagLen);
+        engine.updateAAD(aad, (short) 0, (short) aad.length);
+
+        byte[] encrypted = new byte[payload.length + tagLen];
+        short encryptProcessedBytes = engine.doFinal(payload, (short) 0, (short) payload.length,encrypted, (short) 0);
+
+        assertEquals( encryptProcessedBytes, encrypted.length);
+        assertEquals(true,Arrays.areEqual(ciphertext,encrypted));
+
+        byte[] tag =new byte[tagLen];
+        engine.retrieveTag(tag, (short) 0, (short) tag.length);
+
+        if(have_sample_tag){
+            assertEquals(true,Arrays.areEqual(tag,sample_tag));
+        }
+
+        // Test decryption
+        engine.init(aesKey, Cipher.MODE_DECRYPT, nonce, (short) 0, (short) nonce.length, (short) aad.length, (short) encrypted.length, tagLen);
+        engine.updateAAD(aad, (short) 0, (short) aad.length);
+
+        byte[] decrypted = new byte[payload.length];
+        short decryptProcessedBytes = engine.doFinal(encrypted, (short) 0, (short) encrypted.length, decrypted, (short) 0);
+
+        assertEquals( decryptProcessedBytes, decrypted.length);
+        assertEquals(true,Arrays.areEqual(payload,decrypted));
+
+        // Verify tag
+        assertEquals(true, engine.verifyTag(tag, (short) 0, (short) tag.length,tagLen));
+    }
+
+    public void testAES_CCM_SinglePartEncryptAndDecrypt(){
+        byte[] key256Bit = new byte[256/Byte.SIZE];
+        new Random().nextBytes(key256Bit);
+
+        byte[] nonce96Bit = new byte[96/Byte.SIZE];
+        new Random().nextBytes(nonce96Bit);
+
+        byte[] aad128Bit = new byte[128/Byte.SIZE];
+        new Random().nextBytes(aad128Bit);
+
+        String msg =
+                "Copyright 2022 Licel Corporation.\n" +
+                        "Licensed under the Apache License, Version 2.0 (the \"License\");\n" +
+                        "you may not use this file except in compliance with the License.\n" +
+                        "You may obtain a copy of the License at\n" +
+                        "\n" +
+                        "      http://www.apache.org/licenses/LICENSE-2.0\n" +
+                        "\n" +
+                        "Unless required by applicable law or agreed to in writing, software\n" +
+                        "distributed under the License is distributed on an \"AS IS\" BASIS,\n" +
+                        "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n" +
+                        "See the License for the specific language governing permissions and\n" +
+                        "limitations under the License.\n";
+
+        byte[] msgBytes = msg.getBytes();
+
+        AESKey aesKey = (AESKey) KeyBuilder.buildKey(KeyBuilder.TYPE_AES, KeyBuilder.LENGTH_AES_256, false);
+        aesKey.setKey(key256Bit, (short) 0);
+
+        AEADCipher engine = (AEADCipher) Cipher.getInstance(AEADCipher.ALG_AES_GCM, false);
+
+        final short tagLenInBits = 96;
+        byte[] tag = new byte[tagLenInBits/Byte.SIZE];
+
+        // Test encryption
+        engine.init(aesKey, Cipher.MODE_ENCRYPT,nonce96Bit,(short)0,(short)nonce96Bit.length, (short) aad128Bit.length, (short) msgBytes.length, (short) tag.length);
+        engine.updateAAD(aad128Bit, (short) 0, (short) aad128Bit.length);
+
+        byte[] encrypted = new byte[msgBytes.length + tag.length];
+        short encryptProcessedBytes = engine.doFinal(msgBytes, (short) 0, (short) msgBytes.length,encrypted, (short) 0);
+        assertEquals( encryptProcessedBytes, encrypted.length);
+
+        engine.retrieveTag(tag, (short) 0, (short) tag.length);
+
+        // Decrypt back
+        engine.init(aesKey, Cipher.MODE_DECRYPT,nonce96Bit,(short)0,(short)nonce96Bit.length, (short) aad128Bit.length, (short) encrypted.length, (short) tag.length);
+        engine.updateAAD(aad128Bit, (short) 0, (short) aad128Bit.length);
+
+        byte[] decrypted = new byte[msgBytes.length];
+        short decryptProcessedBytes = engine.doFinal(encrypted, (short) 0, (short) (encrypted.length),decrypted, (short) 0);
+
+        assertEquals( decryptProcessedBytes, decrypted.length);
+        assertEquals(true, Arrays.areEqual(decrypted, msgBytes));
+        assertEquals(true, engine.verifyTag(tag, (short) 0, (short) tag.length, (short)(tagLenInBits/Byte.SIZE)));
+    }
+
+    public void testAES_CCM_MultiplePartEncryptAndDecrypt(){
+        byte[] key256Bit = new byte[256/Byte.SIZE];
+        new Random().nextBytes(key256Bit);
+
+        byte[] nonce96Bit = new byte[96/Byte.SIZE];
+        new Random().nextBytes(nonce96Bit);
+
+        byte[] aad128Bit = new byte[128/Byte.SIZE];
+        new Random().nextBytes(aad128Bit);
+
+        String msgPart1 =
+                "Copyright 2022 Licel Corporation.\n" +
+                        "Licensed under the Apache License, Version 2.0 (the \"License\");\n" +
+                        "you may not use this file except in compliance with the License.\n" +
+                        "You may obtain a copy of the License at\n" +
+                        "\n" +
+                        "      http://www.apache.org/licenses/LICENSE-2.0\n" +
+                        "\n";
+
+        String msgPart2 =
+                "Unless required by applicable law or agreed to in writing, software\n" +
+                        "distributed under the License is distributed on an \"AS IS\" BASIS,\n" +
+                        "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n" +
+                        "See the License for the specific language governing permissions and\n" +
+                        "limitations under the License.\n";
+
+
+        AESKey aesKey = (AESKey) KeyBuilder.buildKey(KeyBuilder.TYPE_AES, KeyBuilder.LENGTH_AES_256, false);
+        aesKey.setKey(key256Bit, (short) 0);
+
+        AEADCipher engine = (AEADCipher) Cipher.getInstance(AEADCipher.ALG_AES_CCM, false);
+
+        final short tagLenInBits = 96;
+        byte[] tag = new byte[tagLenInBits/Byte.SIZE];
+
+        short totalMsgLen = (short)( msgPart1.length() + msgPart2.length());
+        // Test encryption
+        engine.init(aesKey, Cipher.MODE_ENCRYPT,nonce96Bit,(short)0,(short)nonce96Bit.length, (short) aad128Bit.length, totalMsgLen, (short) tag.length);
+        engine.updateAAD(aad128Bit, (short) 0, (short) aad128Bit.length);
+
+        byte[] encrypted = new byte[totalMsgLen + tag.length ];
+
+        short encryptProcessedBytes = engine.update( msgPart1.getBytes(),(short) 0, (short) msgPart1.length(),encrypted,(short) 0);
+        encryptProcessedBytes += engine.doFinal(msgPart2.getBytes(), (short) 0, (short) msgPart2.length(),encrypted, (short) encryptProcessedBytes);
+        assertEquals( encryptProcessedBytes, encrypted.length);
+
+        engine.retrieveTag(tag, (short) 0, (short) tag.length);
+
+        // Decrypt back
+        engine.init(aesKey, Cipher.MODE_DECRYPT,nonce96Bit,(short)0,(short)nonce96Bit.length, (short) aad128Bit.length, (short)encrypted.length, (short) tag.length);
+        engine.updateAAD(aad128Bit, (short) 0, (short) aad128Bit.length);
+
+        byte[] decrypted = new byte[totalMsgLen];
+        short decryptProcessedBytes = engine.doFinal(encrypted, (short) 0, (short) (encrypted.length),decrypted, (short) 0);
+
+        assertEquals( decryptProcessedBytes, decrypted.length);
+        assertEquals(true, Arrays.areEqual(decrypted, 0, msgPart1.length(), msgPart1.getBytes(), 0, msgPart1.length()));
+        assertEquals(true, Arrays.areEqual(decrypted, msgPart1.length(), decrypted.length, msgPart2.getBytes(), 0, msgPart2.length()));
+        assertEquals(true, engine.verifyTag(tag, (short) 0, (short) tag.length, (short)(tagLenInBits/Byte.SIZE)));
+    }
+}


### PR DESCRIPTION
Use example vectors from below links
CCM
https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38c.pdf https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/mac/ccmtestvectors.zip
GCM
https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/mac/gcmtestvectors.zip

Due to javacard 3.0.5 supports only the 12 byte IV length, which is the value recommended by NIST Special Publication 800-38D 5.2.1.1 Input Data, so the cipher is implemented and tested with 12-byte IV limitation
https://docs.oracle.com/javacard/3.0.5/guide/supported-cryptography-classes.htm#JCUGC356