### PR TITLE
Remove out printing trace stack in SimulatorSystem and CardManager

### DIFF
--- a/src/main/java/com/licel/jcardsim/base/CardManager.java
+++ b/src/main/java/com/licel/jcardsim/base/CardManager.java
@@ -31,7 +31,6 @@ public class CardManager implements CardManagerInterface {
             impl = (CardManagerInterface)Class.forName("com.licel.globalplatform.CardManager").newInstance();
             System.out.println("Succesfully loaded the instance!");
         } catch (Throwable ex) {
-            ex.printStackTrace(System.err);
             System.out.println("Failed to load the instance! Will use the default CardManager");
             impl = new CardManager();
         }

--- a/src/main/java/com/licel/jcardsim/base/SimulatorSystem.java
+++ b/src/main/java/com/licel/jcardsim/base/SimulatorSystem.java
@@ -59,7 +59,6 @@ public class SimulatorSystem {
             sim = setCurrentInstance((SimulatorRuntime)Class.forName("com.licel.globalplatform.GpSimulatorRuntime").newInstance());
             System.out.println("Succesfully loaded the instance!");
         } catch (Throwable ex) {
-            ex.printStackTrace(System.err);
             System.out.println("Failed to load the instance! Will use the default SimulatorRuntime");
             sim = setCurrentInstance(new SimulatorRuntime());
         }


### PR DESCRIPTION
To prevent confusion in failed loading globalplatform package then use default instead  #179 