### PR TITLE
Support AES_CTR Cipher and add proxy tests for checking not implemented

### DIFF
--- a/src/main/java/com/licel/jcardsim/crypto/CipherProxy.java
+++ b/src/main/java/com/licel/jcardsim/crypto/CipherProxy.java
@@ -57,6 +57,7 @@ public class CipherProxy {
             case Cipher.ALG_AES_BLOCK_128_CBC_NOPAD:
             case Cipher.ALG_AES_BLOCK_128_ECB_NOPAD:
             case Cipher.ALG_AES_CBC_ISO9797_M2:
+            case Cipher.ALG_AES_CTR:
                 instance = new SymmetricCipherImpl(algorithm);
                 break;
             case Cipher.ALG_RSA_PKCS1:

--- a/src/main/java/com/licel/jcardsim/crypto/SymmetricCipherImpl.java
+++ b/src/main/java/com/licel/jcardsim/crypto/SymmetricCipherImpl.java
@@ -21,7 +21,9 @@ import javacard.security.Key;
 import javacard.security.KeyBuilder;
 import javacardx.crypto.Cipher;
 import org.bouncycastle.crypto.BufferedBlockCipher;
+import org.bouncycastle.crypto.engines.AESEngine;
 import org.bouncycastle.crypto.modes.CBCBlockCipher;
+import org.bouncycastle.crypto.modes.SICBlockCipher;
 import org.bouncycastle.crypto.paddings.ISO7816d4Padding;
 import org.bouncycastle.crypto.paddings.PKCS7Padding;
 import org.bouncycastle.crypto.paddings.PaddedBufferedBlockCipher;
@@ -143,6 +145,9 @@ public class SymmetricCipherImpl extends Cipher {
                 break;
             case ALG_AES_CBC_ISO9797_M2:
                 engine = new PaddedBufferedBlockCipher(new CBCBlockCipher(key.getCipher()), new ISO7816d4Padding());
+                break;
+            case ALG_AES_CTR:
+                engine = new BufferedBlockCipher(new SICBlockCipher(key.getCipher()));
                 break;
             default:
                 CryptoException.throwIt(CryptoException.NO_SUCH_ALGORITHM);

--- a/src/test/java/com/licel/jcardsim/crypto/CipherProxyTest.java
+++ b/src/test/java/com/licel/jcardsim/crypto/CipherProxyTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 Licel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.licel.jcardsim.crypto;
+
+import javacardx.crypto.Cipher;
+import junit.framework.TestCase;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class CipherProxyTest extends TestCase {
+    public CipherProxyTest(String testName) {
+        super(testName);
+    }
+
+    protected void setUp() throws Exception {
+        super.setUp();
+    }
+
+    protected void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    // The deprecated cipher algorithm list is created because JavaCard 3.0.5 API uses only javadoc annotation @deprecated
+    // And not use the Java annotation @Deprecated, which can be read by java.lang.reflect.Field
+    // https://docs.oracle.com/javacard/3.0.5/api/javacardx/crypto/Cipher.html
+    String[] CIPHER_DEPRECATED_ALG_JAVACARD_V3_0_5 = {
+        "ALG_AES_BLOCK_192_CBC_NOPAD",
+        "ALG_AES_BLOCK_192_ECB_NOPAD",
+        "ALG_AES_BLOCK_256_CBC_NOPAD",
+        "ALG_AES_BLOCK_256_ECB_NOPAD",
+        "ALG_RSA_ISO14888",
+        "ALG_RSA_ISO9796",
+    };
+
+    public void testSupportCipherForJavaCardv3_0_5() throws ClassNotFoundException {
+        ArrayList<Field> cipher_alg_fields = new ArrayList<Field>();
+
+        for(Field field : Class.forName("javacardx.crypto.Cipher").getDeclaredFields()){
+            if( field.getName().startsWith("ALG_") ){
+                List<String> deprecated_list = Arrays.asList(CIPHER_DEPRECATED_ALG_JAVACARD_V3_0_5);
+                if( !deprecated_list.contains(field.getName()))
+                    cipher_alg_fields.add(field);
+            }
+        }
+
+        for( Field alg_field : cipher_alg_fields ) {
+            try {
+                Cipher engine = Cipher.getInstance(alg_field.getByte(null), false);
+            }
+            catch (Throwable ex){
+                System.out.println("Cipher algorithm " + alg_field.getName() + " has not been implemented yet!!!");
+            }
+        }
+
+    }
+}

--- a/src/test/java/com/licel/jcardsim/crypto/MessageDigestProxyTest.java
+++ b/src/test/java/com/licel/jcardsim/crypto/MessageDigestProxyTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 Licel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.licel.jcardsim.crypto;
+
+import javacard.security.MessageDigest;
+import javacard.security.Signature;
+import junit.framework.TestCase;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class MessageDigestProxyTest extends TestCase {
+    public MessageDigestProxyTest(String testName) {
+        super(testName);
+    }
+
+    protected void setUp() throws Exception {
+        super.setUp();
+    }
+
+    protected void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+
+    public void testSupportMessageDigestForJavaCardv3_0_5() throws ClassNotFoundException {
+
+        ArrayList<Field> md_alg_fields = new ArrayList<>();
+
+        for(Field field : Class.forName("javacard.security.MessageDigest").getDeclaredFields()){
+            if( field.getName().startsWith("ALG_") ){
+                md_alg_fields.add(field);
+            }
+        }
+
+        for( Field alg_field : md_alg_fields ) {
+            try {
+                MessageDigest md = MessageDigest.getInstance(alg_field.getByte(null), false);
+            }
+            catch (Throwable ex){
+                System.out.println("Message Digest algorithm " + alg_field.getName() + " has not been implemented yet!!!");
+            }
+        }
+
+    }
+}

--- a/src/test/java/com/licel/jcardsim/crypto/SignatureProxyTest.java
+++ b/src/test/java/com/licel/jcardsim/crypto/SignatureProxyTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 Licel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.licel.jcardsim.crypto;
+
+import javacard.security.Signature;
+import junit.framework.TestCase;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class SignatureProxyTest extends TestCase {
+    public SignatureProxyTest(String testName) {
+        super(testName);
+    }
+
+    protected void setUp() throws Exception {
+        super.setUp();
+    }
+
+    protected void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    // The deprecated signature algorithm list is created because JavaCard 3.0.5 API uses only javadoc annotation @deprecated
+    // And not use the Java annotation @Deprecated, which can be read by java.lang.reflect.Field
+    // https://docs.oracle.com/javacard/3.0.5/api/javacard/security/Signature.html
+    String[] SIGNATURE_DEPRECATED_ALG_JAVACARD_V3_0_5 = {
+            "ALG_AES_MAC_192_NOPAD",
+            "ALG_AES_MAC_256_NOPAD",
+    };
+
+    public void testSupportSignatureForJavaCardv3_0_5() throws ClassNotFoundException {
+
+        ArrayList<Field> signature_alg_fields = new ArrayList<>();
+
+        for(Field field : Class.forName("javacard.security.Signature").getDeclaredFields()){
+            if( field.getName().startsWith("ALG_") ){
+                List<String> deprecated_list = Arrays.asList(SIGNATURE_DEPRECATED_ALG_JAVACARD_V3_0_5);
+                if( !deprecated_list.contains(field.getName()))
+                    signature_alg_fields.add(field);
+            }
+        }
+
+        for( Field alg_field : signature_alg_fields ) {
+            try {
+                Signature sig = Signature.getInstance(alg_field.getByte(null), false);
+            }
+            catch (Throwable ex){
+                System.out.println("Signature algorithm " + alg_field.getName() + " has not been implemented yet!!!");
+            }
+        }
+
+    }
+}

--- a/src/test/java/com/licel/jcardsim/crypto/SymmetricCipherImplTest.java
+++ b/src/test/java/com/licel/jcardsim/crypto/SymmetricCipherImplTest.java
@@ -112,6 +112,12 @@ public class SymmetricCipherImplTest extends TestCase {
     // Appendix F.2.5
     String[] AES_CBC_256_TEST = {"603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4", "000102030405060708090a0b0c0d0e0f", "6bc1bee22e409f96e93d7e117393172a", "f58c4c04d6e5f1ba779eabfb5f7bfbd6"};
 
+    // AES CTR test vectors from NIST (sp800-38a)
+    // FORMAT: key:counter:plaintext:ciphertext
+    // Appendix F.5.1
+    String[] AES_CTR_128_TEST = {"2b7e151628aed2a6abf7158809cf4f3c", "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff","6bc1bee22e409f96e93d7e117393172a","874d6191b620e3261bef6864990db6ce"};
+    String[] AES_CTR_192_TEST = {"8e73b0f7da0e6452c810f32b809079e562f8ead2522c6b7b", "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff","6bc1bee22e409f96e93d7e117393172a","1abc932417521ca24f2b0459fe7e6e0b"};
+    String[] AES_CTR_256_TEST = {"603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4", "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff","6bc1bee22e409f96e93d7e117393172a","601ec313775789a5b7a7f504bbf3d228"};
     public SymmetricCipherImplTest(String testName) {
         super(testName);
     }
@@ -484,4 +490,86 @@ public class SymmetricCipherImplTest extends TestCase {
         assertEquals(ISO7816.SW_UNKNOWN, Util.getShort(response, (short) 0));
 
     }
+
+    public void testAES_CTR_128BitKey(){
+        Cipher engine = Cipher.getInstance(Cipher.ALG_AES_CTR,false);
+        AESKey aesKey = (AESKey) KeyBuilder.buildKey(KeyBuilder.TYPE_AES, KeyBuilder.LENGTH_AES_128, false);
+        short keyLenInBytes = (short) (KeyBuilder.LENGTH_AES_128 / Byte.SIZE);
+        byte[] etalonKey = Hex.decode(AES_CTR_128_TEST[0]);
+        byte[] key = new byte[keyLenInBytes];
+        Util.arrayCopy(etalonKey, (short) 0, key, (short) 0, (short) etalonKey.length);
+        aesKey.setKey(key, (short) 0);
+
+        byte[] initCounter = Hex.decode(AES_CTR_128_TEST[1]);
+        engine.init(aesKey,Cipher.MODE_ENCRYPT,initCounter, (short) 0, (short) initCounter.length);
+
+        byte[] msg = Hex.decode(AES_CTR_128_TEST[2]);
+        byte[] encrypted = new byte[msg.length];
+        engine.doFinal(msg, (short) 0, (short) msg.length,encrypted, (short) 0);
+
+        byte[] ciphertext = Hex.decode(AES_CTR_128_TEST[3]);
+
+        assertEquals(true,Arrays.areEqual(encrypted, ciphertext));
+
+        engine.init(aesKey,Cipher.MODE_DECRYPT,initCounter, (short) 0, (short) initCounter.length);
+        byte[] decrypted = new byte[encrypted.length];
+        engine.doFinal(encrypted, (short) 0, (short) encrypted.length,decrypted, (short) 0);
+
+        assertEquals(true,Arrays.areEqual(decrypted, msg));
+    }
+
+    public void testAES_CTR_192BitKey(){
+        Cipher engine = Cipher.getInstance(Cipher.ALG_AES_CTR,false);
+        AESKey aesKey = (AESKey) KeyBuilder.buildKey(KeyBuilder.TYPE_AES, KeyBuilder.LENGTH_AES_192, false);
+        short keyLenInBytes = (short) (KeyBuilder.LENGTH_AES_192 / Byte.SIZE);
+        byte[] etalonKey = Hex.decode(AES_CTR_192_TEST[0]);
+        byte[] key = new byte[keyLenInBytes];
+        Util.arrayCopy(etalonKey, (short) 0, key, (short) 0, (short) etalonKey.length);
+        aesKey.setKey(key, (short) 0);
+
+        byte[] initCounter = Hex.decode(AES_CTR_192_TEST[1]);
+        engine.init(aesKey,Cipher.MODE_ENCRYPT,initCounter, (short) 0, (short) initCounter.length);
+
+        byte[] msg = Hex.decode(AES_CTR_192_TEST[2]);
+        byte[] encrypted = new byte[msg.length];
+        engine.doFinal(msg, (short) 0, (short) msg.length,encrypted, (short) 0);
+
+        byte[] ciphertext = Hex.decode(AES_CTR_192_TEST[3]);
+
+        assertEquals(true,Arrays.areEqual(encrypted, ciphertext));
+
+        engine.init(aesKey,Cipher.MODE_DECRYPT,initCounter, (short) 0, (short) initCounter.length);
+        byte[] decrypted = new byte[encrypted.length];
+        engine.doFinal(encrypted, (short) 0, (short) encrypted.length,decrypted, (short) 0);
+
+        assertEquals(true,Arrays.areEqual(decrypted, msg));
+    }
+
+    public void testAES_CTR_256BitKey(){
+        Cipher engine = Cipher.getInstance(Cipher.ALG_AES_CTR,false);
+        AESKey aesKey = (AESKey) KeyBuilder.buildKey(KeyBuilder.TYPE_AES, KeyBuilder.LENGTH_AES_256, false);
+        short keyLenInBytes = (short) (KeyBuilder.LENGTH_AES_256 / Byte.SIZE);
+        byte[] etalonKey = Hex.decode(AES_CTR_256_TEST[0]);
+        byte[] key = new byte[keyLenInBytes];
+        Util.arrayCopy(etalonKey, (short) 0, key, (short) 0, (short) etalonKey.length);
+        aesKey.setKey(key, (short) 0);
+
+        byte[] initCounter = Hex.decode(AES_CTR_256_TEST[1]);
+        engine.init(aesKey,Cipher.MODE_ENCRYPT,initCounter, (short) 0, (short) initCounter.length);
+
+        byte[] msg = Hex.decode(AES_CTR_256_TEST[2]);
+        byte[] encrypted = new byte[msg.length];
+        engine.doFinal(msg, (short) 0, (short) msg.length,encrypted, (short) 0);
+
+        byte[] ciphertext = Hex.decode(AES_CTR_256_TEST[3]);
+
+        assertEquals(true,Arrays.areEqual(encrypted, ciphertext));
+
+        engine.init(aesKey,Cipher.MODE_DECRYPT,initCounter, (short) 0, (short) initCounter.length);
+        byte[] decrypted = new byte[encrypted.length];
+        engine.doFinal(encrypted, (short) 0, (short) encrypted.length,decrypted, (short) 0);
+
+        assertEquals(true,Arrays.areEqual(decrypted, msg));
+    }
+
 }


### PR DESCRIPTION
Use bouncycastle SICBlockCipher as Block cipher for AES_CTR implementation
https://www.javadoc.io/static/org.bouncycastle/bcprov-jdk18on/1.71/org/bouncycastle/crypto/modes/SICBlockCipher.html

Use test vectors from [NIST (sp800-38a)](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38a.pdf), Appendix F.5 CTR Example Vectors

Add CipherProxyTest, SignatureProxyTest and MessageDigestTest to check and print out not implemented modules, excluding deprecated