### PR TITLE
Support ALG_KOREAN_SEED_CBC_NOPAD and ALG_KOREAN_SEED_ECB_NOPAD

### DIFF
--- a/src/main/java/com/licel/jcardsim/crypto/CipherProxy.java
+++ b/src/main/java/com/licel/jcardsim/crypto/CipherProxy.java
@@ -58,6 +58,8 @@ public class CipherProxy {
             case Cipher.ALG_AES_BLOCK_128_ECB_NOPAD:
             case Cipher.ALG_AES_CBC_ISO9797_M2:
             case Cipher.ALG_AES_CTR:
+            case Cipher.ALG_KOREAN_SEED_ECB_NOPAD:
+            case Cipher.ALG_KOREAN_SEED_CBC_NOPAD:
                 instance = new SymmetricCipherImpl(algorithm);
                 break;
             case Cipher.ALG_RSA_PKCS1:

--- a/src/main/java/com/licel/jcardsim/crypto/KeyBuilderProxy.java
+++ b/src/main/java/com/licel/jcardsim/crypto/KeyBuilderProxy.java
@@ -18,6 +18,7 @@ package com.licel.jcardsim.crypto;
 import javacard.security.CryptoException;
 import javacard.security.Key;
 import javacard.security.KeyBuilder;
+import javacard.security.KoreanSEEDKey;
 
 /**
  * ProxyClass for <code>KeyBuilder</code>
@@ -123,7 +124,16 @@ public class KeyBuilderProxy {
             case KeyBuilder.TYPE_DH_PRIVATE:
                 key = new DHPrivateKeyImpl(keyLength);
                 break;
-                
+
+            case KeyBuilder.TYPE_KOREAN_SEED_TRANSIENT_RESET:
+            case KeyBuilder.TYPE_KOREAN_SEED_TRANSIENT_DESELECT:
+            case KeyBuilder.TYPE_KOREAN_SEED:
+                if (keyLength != KeyBuilder.LENGTH_KOREAN_SEED_128) {
+                    CryptoException.throwIt(CryptoException.ILLEGAL_VALUE);
+                }
+                key = new SymmetricKeyImpl(keyType, keyLength);
+
+                break;
             default:
                 CryptoException.throwIt(CryptoException.NO_SUCH_ALGORITHM);
                 break;

--- a/src/main/java/com/licel/jcardsim/crypto/SymmetricCipherImpl.java
+++ b/src/main/java/com/licel/jcardsim/crypto/SymmetricCipherImpl.java
@@ -58,6 +58,7 @@ public class SymmetricCipherImpl extends Cipher {
             case ALG_DES_ECB_ISO9797_M1:
             case ALG_DES_ECB_ISO9797_M2:
             case ALG_DES_ECB_PKCS5:
+            case ALG_KOREAN_SEED_ECB_NOPAD:
                 CryptoException.throwIt(CryptoException.ILLEGAL_VALUE);
                 break;
             case ALG_DES_CBC_NOPAD:
@@ -119,6 +120,7 @@ public class SymmetricCipherImpl extends Cipher {
         switch (algorithm) {
             case ALG_DES_CBC_NOPAD:
             case ALG_AES_BLOCK_128_CBC_NOPAD:
+            case ALG_KOREAN_SEED_CBC_NOPAD:
                 engine = new BufferedBlockCipher(new CBCBlockCipher(key.getCipher()));
                 break;
             case ALG_DES_CBC_ISO9797_M1:
@@ -131,7 +133,8 @@ public class SymmetricCipherImpl extends Cipher {
                 engine = new PaddedBufferedBlockCipher(new CBCBlockCipher(key.getCipher()), new PKCS7Padding());
                 break;
             case ALG_DES_ECB_NOPAD:
-            case ALG_AES_BLOCK_128_ECB_NOPAD:                
+            case ALG_AES_BLOCK_128_ECB_NOPAD:
+            case ALG_KOREAN_SEED_ECB_NOPAD:
                 engine = new BufferedBlockCipher(key.getCipher());
                 break;
             case ALG_DES_ECB_ISO9797_M1:
@@ -158,31 +161,40 @@ public class SymmetricCipherImpl extends Cipher {
     private boolean checkKeyCompatibility(Key theKey){
         switch(theKey.getType()){
             case KeyBuilder.TYPE_DES:
-                case KeyBuilder.TYPE_DES_TRANSIENT_RESET:
-                    case KeyBuilder.TYPE_DES_TRANSIENT_DESELECT:
+            case KeyBuilder.TYPE_DES_TRANSIENT_RESET:
+            case KeyBuilder.TYPE_DES_TRANSIENT_DESELECT:
                 if( (algorithm == Cipher.ALG_DES_CBC_NOPAD) ||
-                        (algorithm == Cipher.ALG_DES_CBC_ISO9797_M1) ||
-                        (algorithm == Cipher.ALG_DES_CBC_ISO9797_M2) ||
-                        (algorithm == Cipher.ALG_DES_CBC_PKCS5) ||
-                        (algorithm == Cipher.ALG_DES_ECB_NOPAD) ||
-                        (algorithm == Cipher.ALG_DES_ECB_ISO9797_M1) ||
-                        (algorithm == Cipher.ALG_DES_ECB_ISO9797_M2) ||
-                        (algorithm == Cipher.ALG_DES_ECB_PKCS5))
+                    (algorithm == Cipher.ALG_DES_CBC_ISO9797_M1) ||
+                    (algorithm == Cipher.ALG_DES_CBC_ISO9797_M2) ||
+                    (algorithm == Cipher.ALG_DES_CBC_PKCS5) ||
+                    (algorithm == Cipher.ALG_DES_ECB_NOPAD) ||
+                    (algorithm == Cipher.ALG_DES_ECB_ISO9797_M1) ||
+                    (algorithm == Cipher.ALG_DES_ECB_ISO9797_M2) ||
+                    (algorithm == Cipher.ALG_DES_ECB_PKCS5))
                     return true;
                 break;
 
             case KeyBuilder.TYPE_AES:
-                case KeyBuilder.TYPE_AES_TRANSIENT_RESET:
-                    case KeyBuilder.TYPE_AES_TRANSIENT_DESELECT:
+            case KeyBuilder.TYPE_AES_TRANSIENT_RESET:
+            case KeyBuilder.TYPE_AES_TRANSIENT_DESELECT:
                 if( (algorithm == Cipher.ALG_AES_CTR) ||
-                        (algorithm == Cipher.ALG_AES_BLOCK_128_CBC_NOPAD) ||
-                        (algorithm == Cipher.ALG_AES_BLOCK_128_ECB_NOPAD) ||
-                        (algorithm == Cipher.ALG_AES_CBC_ISO9797_M1) ||
-                        (algorithm == Cipher.ALG_AES_CBC_ISO9797_M2) ||
-                        (algorithm == Cipher.ALG_AES_CBC_PKCS5) ||
-                        (algorithm == Cipher.ALG_AES_ECB_ISO9797_M1) ||
-                        (algorithm == Cipher.ALG_AES_ECB_ISO9797_M2) ||
-                        (algorithm == Cipher.ALG_AES_ECB_PKCS5))
+                    (algorithm == Cipher.ALG_AES_BLOCK_128_CBC_NOPAD) ||
+                    (algorithm == Cipher.ALG_AES_BLOCK_128_ECB_NOPAD) ||
+                    (algorithm == Cipher.ALG_AES_CBC_ISO9797_M1) ||
+                    (algorithm == Cipher.ALG_AES_CBC_ISO9797_M2) ||
+                    (algorithm == Cipher.ALG_AES_CBC_PKCS5) ||
+                    (algorithm == Cipher.ALG_AES_ECB_ISO9797_M1) ||
+                    (algorithm == Cipher.ALG_AES_ECB_ISO9797_M2) ||
+                    (algorithm == Cipher.ALG_AES_ECB_PKCS5))
+                    return true;
+                break;
+
+
+            case KeyBuilder.TYPE_KOREAN_SEED:
+            case KeyBuilder.TYPE_KOREAN_SEED_TRANSIENT_RESET:
+            case KeyBuilder.TYPE_KOREAN_SEED_TRANSIENT_DESELECT:
+                if( (algorithm == Cipher.ALG_KOREAN_SEED_CBC_NOPAD) ||
+                    (algorithm == Cipher.ALG_KOREAN_SEED_ECB_NOPAD) )
                     return true;
                 break;
         }

--- a/src/main/java/com/licel/jcardsim/crypto/SymmetricKeyImpl.java
+++ b/src/main/java/com/licel/jcardsim/crypto/SymmetricKeyImpl.java
@@ -17,25 +17,24 @@ package com.licel.jcardsim.crypto;
 
 import java.security.SecureRandom;
 import javacard.framework.JCSystem;
-import javacard.security.AESKey;
-import javacard.security.CryptoException;
-import javacard.security.DESKey;
-import javacard.security.HMACKey;
-import javacard.security.KeyBuilder;
+import javacard.security.*;
 import org.bouncycastle.crypto.BlockCipher;
 import org.bouncycastle.crypto.CipherParameters;
 import org.bouncycastle.crypto.KeyGenerationParameters;
 import org.bouncycastle.crypto.engines.AESEngine;
 import org.bouncycastle.crypto.engines.DESEngine;
 import org.bouncycastle.crypto.engines.DESedeEngine;
+import org.bouncycastle.crypto.engines.SEEDEngine;
 import org.bouncycastle.crypto.params.KeyParameter;
 
 /**
  * Implementation of secret key.
  * @see DESKey
  * @see AESKey
+ * @see HMACKey
+ * @see KoreanSEEDKey
  */
-public class SymmetricKeyImpl extends KeyImpl implements DESKey, AESKey, HMACKey {
+public class SymmetricKeyImpl extends KeyImpl implements DESKey, AESKey, HMACKey, KoreanSEEDKey {
 
     protected ByteContainer key;
 
@@ -52,16 +51,19 @@ public class SymmetricKeyImpl extends KeyImpl implements DESKey, AESKey, HMACKey
             case KeyBuilder.TYPE_DES_TRANSIENT_DESELECT:
             case KeyBuilder.TYPE_AES_TRANSIENT_DESELECT:
             case KeyBuilder.TYPE_HMAC_TRANSIENT_DESELECT:
+            case KeyBuilder.TYPE_KOREAN_SEED_TRANSIENT_DESELECT:
                 key = new ByteContainer(JCSystem.MEMORY_TYPE_TRANSIENT_DESELECT);
                 break;
             case KeyBuilder.TYPE_DES_TRANSIENT_RESET:
             case KeyBuilder.TYPE_AES_TRANSIENT_RESET:
             case KeyBuilder.TYPE_HMAC_TRANSIENT_RESET:
+            case KeyBuilder.TYPE_KOREAN_SEED_TRANSIENT_RESET:
                 key = new ByteContainer(JCSystem.MEMORY_TYPE_TRANSIENT_RESET);
                 break;
             case KeyBuilder.TYPE_DES:
             case KeyBuilder.TYPE_AES:
             case KeyBuilder.TYPE_HMAC:
+            case KeyBuilder.TYPE_KOREAN_SEED:
                 key = new ByteContainer(JCSystem.MEMORY_TYPE_PERSISTENT);
                 break;
         }
@@ -137,6 +139,12 @@ public class SymmetricKeyImpl extends KeyImpl implements DESKey, AESKey, HMACKey
             case KeyBuilder.TYPE_AES_TRANSIENT_DESELECT:
             case KeyBuilder.TYPE_AES_TRANSIENT_RESET:
                 cipher = new AESEngine();
+                break;
+
+            case KeyBuilder.TYPE_KOREAN_SEED:
+            case KeyBuilder.TYPE_KOREAN_SEED_TRANSIENT_DESELECT:
+            case KeyBuilder.TYPE_KOREAN_SEED_TRANSIENT_RESET:
+                cipher = new SEEDEngine();
                 break;
         }
         return cipher;


### PR DESCRIPTION
Use [SEEDEngine](https://www.javadoc.io/static/org.bouncycastle/bcprov-jdk18on/1.71/org/bouncycastle/crypto/engines/SEEDEngine.html ) as key cipher engine.

Use test vectors in Appendix B of [RFC4269](https://www.rfc-editor.org/rfc/pdfrfc/rfc4269.txt.pdf) for test