### PR TITLE
Added sample applet for testing the simulator runtime with APDU extend cases

### DIFF
--- a/src/main/java/com/licel/jcardsim/samples/ApduExtendedCasesApplet.java
+++ b/src/main/java/com/licel/jcardsim/samples/ApduExtendedCasesApplet.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2022 Licel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.licel.jcardsim.samples;
+
+import javacard.framework.*;
+import javacardx.apdu.ExtendedLength;
+
+/**
+ * Applet for testing the extended APDU cases.
+ *
+ * Especial for zero-value of byte at Le/Lc position (offset = 4 ).
+ *
+ * <p>Supported only single APDU format:</p>
+ * <code>CLA=0x80 INS=0xb4 P1=0 P2=0</code>
+ * <ul>
+ *     <li>Case 2, send back 0x5A which number of bytes according to Le</li>
+ *     <li>Case 2E, send back 0x5A which number of bytes according to 3-byte Le</li>
+ *     <li>Case 3E, receive and check data must be 0x5A which number of bytes according to 3-byte Lc /li>
+ *     <li>Case 4, receive a zero-value byte and send back 0x5A which number of bytes according to Le/li>
+ *     <li>Case 4E, receive and check data must be all 0x5A which number of bytes according to 3-byte Lc then send back 0x5A which number of bytes according to 2-byte Le/li>
+ * </ul>
+ */
+public class ApduExtendedCasesApplet extends BaseApplet implements ExtendedLength {
+    private static final byte CLA = (byte) 0x80;
+    private static final byte INS = (byte) 0xb4;
+
+    private static final byte P1 = (byte) 0;
+    private static final byte P2 = (byte) 0;
+
+    protected ApduExtendedCasesApplet(){
+        register();
+    }
+
+    public static void install(byte[] bArray, short bOffset, byte bLength)
+            throws ISOException {
+        new ApduExtendedCasesApplet();
+    }
+
+    @Override
+    public void process(APDU apdu) throws ISOException {
+        if(selectingApplet()) {
+            return;
+        }
+
+        byte[] buffer = apdu.getBuffer();
+
+        if( buffer[ISO7816.OFFSET_CLA] != CLA){
+            ISOException.throwIt(ISO7816.SW_CLA_NOT_SUPPORTED);
+        }
+        if( (buffer[ISO7816.OFFSET_P1] != P1) || (buffer[ISO7816.OFFSET_P2] != P2)  ){
+            ISOException.throwIt(ISO7816.SW_WRONG_P1P2);
+        }
+
+        switch(buffer[ISO7816.OFFSET_INS]){
+            case INS :
+                processCommand(apdu);
+                break;
+            default:
+                ISOException.throwIt(ISO7816.SW_INS_NOT_SUPPORTED);
+        }
+    }
+
+    private void processCommand(APDU apdu){
+
+        byte[] buffer = apdu.getBuffer();
+
+        short readCount = apdu.setIncomingAndReceive();
+        short Lc = apdu.getIncomingLength();
+        short offsetCData = apdu.getOffsetCdata();
+        short read = readCount;
+        while(read < Lc) {
+            read += apdu.receiveBytes(read);
+        }
+
+        short Ne = apdu.setOutgoing();
+
+        if( Lc == 0 ){
+            if( Ne > 0 ){
+                send0x5aData(apdu, Ne);
+                return;
+            }
+
+            ISOException.throwIt(ISO7816.SW_COMMAND_NOT_ALLOWED);
+        }
+        else{
+            byte[] CDataBytes = JCSystem.makeTransientByteArray(read, JCSystem.CLEAR_ON_DESELECT);
+            Util.arrayCopyNonAtomic(buffer, offsetCData, CDataBytes, (short) 0, readCount);
+            if( CDataBytes.length == 1 ){
+                if(CDataBytes[0] == 0){
+                    send0x5aData(apdu, Ne);
+                }
+                else{
+                    ISOException.throwIt(ISO7816.SW_COMMAND_NOT_ALLOWED);
+                }
+            }
+            else{
+                if(Ne > 0){
+                    // Check content
+                    for(short i = 0; i < Lc; i++){
+                        if(CDataBytes[i] != 0x5a){
+                            ISOException.throwIt(ISO7816.SW_DATA_INVALID);
+                        }
+                    }
+                    // Echo data back
+                    apdu.setOutgoingLength(Ne);
+                    apdu.sendBytesLong(CDataBytes, (short) 0, Ne);
+                }
+                else{
+                    // Check content
+                    for(short i = 0; i < Lc; i++){
+                        if(CDataBytes[i] != 0x5a){
+                            ISOException.throwIt(ISO7816.SW_DATA_INVALID);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static void send0x5aData(APDU apdu, short Ne) {
+        byte[] tmp = JCSystem.makeTransientByteArray(Ne, JCSystem.CLEAR_ON_DESELECT);
+        for (short i = 0; i < Ne; i++) {
+            tmp[i] = 0x5a;
+        }
+
+        apdu.setOutgoingLength(Ne);
+        apdu.sendBytesLong(tmp, (short) 0, Ne);
+    }
+}

--- a/src/test/java/com/licel/jcardsim/base/ApduExtendedCasesTest.java
+++ b/src/test/java/com/licel/jcardsim/base/ApduExtendedCasesTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2022 Licel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.licel.jcardsim.base;
+
+import com.licel.jcardsim.samples.ApduExtendedCasesApplet;
+import com.licel.jcardsim.utils.AIDUtil;
+import javacard.framework.AID;
+import javacard.framework.ISO7816;
+import junit.framework.TestCase;
+import org.bouncycastle.util.Arrays;
+import javax.smartcardio.ResponseAPDU;
+
+
+public class ApduExtendedCasesTest extends TestCase {
+
+    private static final byte CLA = (byte) 0x80;
+    private static final byte INS = (byte)0xb4;
+    private static final byte P1 = (byte) 0;
+    private static final byte P2 = (byte) 0;
+    byte[] appletAIDBytes = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09 };
+    protected void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    public void testApduCase2_Request256BytesWithLeZeroValue(){
+        Simulator instance = getReadySimulator();
+
+        byte Le = 0;
+        byte[] apdu = new byte[]{CLA, INS, P1, P2, Le};
+        byte[] response = instance.transmitCommand(apdu);
+        ResponseAPDU responseApdu = new ResponseAPDU(response);
+        assertEquals(ISO7816.SW_NO_ERROR,(short) responseApdu.getSW() );
+
+        // Check content
+        for( short i = 0 ; i < 256; i++){
+            assertEquals((byte)0x5a,response[i]);
+        }
+
+    }
+
+    public void testApduCase2E_Request256BytesWith3ByteLe(){
+        Simulator instance = getReadySimulator();
+
+        //  Le = 0x00, 0x01,0x00 -> 256
+        byte[] apdu = new byte[]{CLA, INS, P1, P2, 0x00, 0x01,0x00};
+        byte[] response = instance.transmitCommand(apdu);
+        ResponseAPDU responseApdu = new ResponseAPDU(response);
+        assertEquals(ISO7816.SW_NO_ERROR,(short) responseApdu.getSW() );
+
+        // Check content
+        for( short i = 0 ; i < 256; i++){
+            assertEquals((byte)0x5a,response[i]);
+        }
+    }
+
+    public void testApduCase3E_Send256Bytes(){
+        Simulator instance = getReadySimulator();
+
+        //  Lc = 0x00, 0x01,0x00 -> 256
+        byte[] apduHeader_Case3E =new byte[]{CLA, INS, P1, P2, 0x00, 0x01, 0x00};
+        byte[] data = new byte[256];
+        Arrays.fill(data, (byte) 0x5a);
+
+        byte[] apdu = new byte[apduHeader_Case3E.length + data.length];
+
+        System.arraycopy(apduHeader_Case3E, 0, apdu, 0, apduHeader_Case3E.length);
+        System.arraycopy(data, 0, apdu, apduHeader_Case3E.length, data.length);
+
+        byte[] response = instance.transmitCommand(apdu);
+        ResponseAPDU responseApdu = new ResponseAPDU(response);
+        assertEquals(ISO7816.SW_NO_ERROR,(short) responseApdu.getSW() );
+    }
+
+
+    public void testApduCase4_Request256BytesWithLeZeroValue(){
+        Simulator instance = getReadySimulator();
+
+        byte Lc = 0x01;
+        byte CData = 0;
+        byte Le = 0;
+        byte[] apdu = new byte[]{CLA, INS, P1, P2, Lc, CData, Le};
+        byte[] response = instance.transmitCommand(apdu);
+        ResponseAPDU responseApdu = new ResponseAPDU(response);
+        assertEquals(ISO7816.SW_NO_ERROR,(short) responseApdu.getSW() );
+
+        // Check content
+        for( short i = 0 ; i < 256; i++){
+            assertEquals((byte)0x5a,response[i]);
+        }
+
+    }
+
+    public void testApduCase4E_Send256BytesAndRequest256Bytes() {
+        Simulator instance = getReadySimulator();
+        // Lc = 0x00, 0x01, 0x00 -> 256
+        byte[] Lc = new byte[]{0x00, 0x01, 0x00};
+        byte[] data = new byte[256];
+        Arrays.fill(data, (byte) 0x5a);
+
+        // Le = 0x01, 0x00 -> Le contains only 2 bytes with the valid data, without the first zero byte.
+        byte[] Le = new byte[]{0x01, 0x00};
+
+        byte[] apduHeader =new byte[]{CLA, INS, P1, P2};
+
+        byte[] apduCase4E = new byte[apduHeader.length + Lc.length + data.length + Le.length];
+
+        System.arraycopy(apduHeader,0, apduCase4E, 0, apduHeader.length);
+        System.arraycopy(Lc,0,apduCase4E,apduHeader.length,Lc.length);
+        System.arraycopy(data,0,apduCase4E, apduHeader.length + Lc.length, data.length);
+        System.arraycopy(Le, 0, apduCase4E, apduHeader.length + Lc.length + data.length, Le.length);
+
+        byte[] response = instance.transmitCommand(apduCase4E);
+
+        ResponseAPDU responseApdu = new ResponseAPDU(response);
+        assertEquals(ISO7816.SW_NO_ERROR, (short)responseApdu.getSW());
+
+        // Check content
+        for( short i = 0 ; i < 256; i++){
+            assertEquals((byte)0x5a,response[i]);
+        }
+
+    }
+        private Simulator getReadySimulator() {
+        Simulator instance = new Simulator();
+        AID appletAID = AIDUtil.create(appletAIDBytes);
+
+        instance.installApplet(appletAID, ApduExtendedCasesApplet.class);
+        instance.selectApplet(appletAID);
+        return instance;
+    }
+}

--- a/src/test/java/com/licel/jcardsim/crypto/AsymmetricCipherImplTest.java
+++ b/src/test/java/com/licel/jcardsim/crypto/AsymmetricCipherImplTest.java
@@ -24,6 +24,8 @@ import javacardx.crypto.Cipher;
 import junit.framework.TestCase;
 import org.bouncycastle.util.Arrays;
 
+import java.util.Random;
+
 /**
  * Test for <code>AsymmetricCipherImpl</code>
  * Test data from NXP JCOP31-36 JavaCard
@@ -45,16 +47,251 @@ public class AsymmetricCipherImplTest extends TestCase {
     /**
      * SelfTest of RSA Encryption/Decryption, of class AsymmetricCipherImpl.
      */
-    public void testSelftRSA() {
-        Cipher cipher = Cipher.getInstance(Cipher.ALG_RSA_NOPAD, false);
-        KeyPair kp = new KeyPair(KeyPair.ALG_RSA_CRT, KeyBuilder.LENGTH_RSA_1024);
+    public void testSelftRSA_NOPAD(){
+        testSelftRSA(Cipher.ALG_RSA_NOPAD, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_512, (short) ((KeyBuilder.LENGTH_RSA_512/Byte.SIZE) - 1));
+        testSelftRSA(Cipher.ALG_RSA_NOPAD, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_736, (short) ((KeyBuilder.LENGTH_RSA_736/Byte.SIZE) - 1));
+        testSelftRSA(Cipher.ALG_RSA_NOPAD, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_768, (short) ((KeyBuilder.LENGTH_RSA_768/Byte.SIZE) - 1));
+        testSelftRSA(Cipher.ALG_RSA_NOPAD, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_896, (short) ((KeyBuilder.LENGTH_RSA_896/Byte.SIZE) - 1));
+        testSelftRSA(Cipher.ALG_RSA_NOPAD, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_1024, (short) ((KeyBuilder.LENGTH_RSA_1024/Byte.SIZE) - 1));
+        testSelftRSA(Cipher.ALG_RSA_NOPAD, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_1280, (short) ((KeyBuilder.LENGTH_RSA_1280/Byte.SIZE) - 1));
+        testSelftRSA(Cipher.ALG_RSA_NOPAD, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_1536, (short) ((KeyBuilder.LENGTH_RSA_1536/Byte.SIZE) - 1));
+        testSelftRSA(Cipher.ALG_RSA_NOPAD, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_1984, (short) ((KeyBuilder.LENGTH_RSA_1984/Byte.SIZE) - 1));
+        testSelftRSA(Cipher.ALG_RSA_NOPAD, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_2048, (short) ((KeyBuilder.LENGTH_RSA_2048/Byte.SIZE) - 1));
+        testSelftRSA(Cipher.ALG_RSA_NOPAD, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_3072, (short) ((KeyBuilder.LENGTH_RSA_3072/Byte.SIZE) - 1));
+        testSelftRSA(Cipher.ALG_RSA_NOPAD, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_4096, (short) ((KeyBuilder.LENGTH_RSA_4096/Byte.SIZE) - 1));
+    }
+    
+    public void testSelftRSA_PKCS1(){
+        // Refer to https://www.rfc-editor.org/rfc/rfc8017#section-7.2.1 and https://docs.oracle.com/javacard/3.0.5/api/javacardx/crypto/Cipher.html#ALG_RSA_PKCS1
+        // mLen <= k - 11, k is the length in octets of the modulus n
+
+        // Test at maximum message length, mLen = k - 11
+        // RSA Key Pair
+        short k = KeyBuilder.LENGTH_RSA_512/Byte.SIZE;
+        short maxMsgLen = (short) (k - 11);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_512, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_736/Byte.SIZE;
+        maxMsgLen = (short) (k - 11);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_736, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_768/Byte.SIZE;
+        maxMsgLen = (short) (k - 11);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_768, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_896/Byte.SIZE;
+        maxMsgLen = (short) (k - 11);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_896, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_1024/Byte.SIZE;
+        maxMsgLen = (short) (k - 11);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_1024, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_1280/Byte.SIZE;
+        maxMsgLen = (short) (k - 11);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_1280, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_1536/Byte.SIZE;
+        maxMsgLen = (short) (k - 11);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_1536, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_1984/Byte.SIZE;
+        maxMsgLen = (short) (k - 11);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_1984, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_2048/Byte.SIZE;
+        maxMsgLen = (short) (k - 11);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_2048, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_3072/Byte.SIZE;
+        maxMsgLen = (short) (k - 11);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_3072, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_4096/Byte.SIZE;
+        maxMsgLen = (short) (k - 11);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_4096, maxMsgLen);
+
+        // RSA Key Pair with private key in its Chinese Remainder Theorem form
+        k = KeyBuilder.LENGTH_RSA_512/Byte.SIZE;
+        maxMsgLen = (short) (k - 11);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1, KeyPair.ALG_RSA_CRT, KeyBuilder.LENGTH_RSA_512, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_736/Byte.SIZE;
+        maxMsgLen = (short) (k - 11);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1, KeyPair.ALG_RSA_CRT, KeyBuilder.LENGTH_RSA_736, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_768/Byte.SIZE;
+        maxMsgLen = (short) (k - 11);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1, KeyPair.ALG_RSA_CRT, KeyBuilder.LENGTH_RSA_768, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_896/Byte.SIZE;
+        maxMsgLen = (short) (k - 11);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1, KeyPair.ALG_RSA_CRT, KeyBuilder.LENGTH_RSA_896, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_1024/Byte.SIZE;
+        maxMsgLen = (short) (k - 11);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1, KeyPair.ALG_RSA_CRT, KeyBuilder.LENGTH_RSA_1024, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_1280/Byte.SIZE;
+        maxMsgLen = (short) (k - 11);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1, KeyPair.ALG_RSA_CRT, KeyBuilder.LENGTH_RSA_1280, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_1536/Byte.SIZE;
+        maxMsgLen = (short) (k - 11);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1, KeyPair.ALG_RSA_CRT, KeyBuilder.LENGTH_RSA_1536, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_1984/Byte.SIZE;
+        maxMsgLen = (short) (k - 11);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1, KeyPair.ALG_RSA_CRT, KeyBuilder.LENGTH_RSA_1984,  maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_2048/Byte.SIZE;
+        maxMsgLen = (short) (k - 11);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1, KeyPair.ALG_RSA_CRT, KeyBuilder.LENGTH_RSA_2048, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_3072/Byte.SIZE;
+        maxMsgLen = (short) (k - 11);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1, KeyPair.ALG_RSA_CRT, KeyBuilder.LENGTH_RSA_3072, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_4096/Byte.SIZE;
+        maxMsgLen = (short) (k - 11);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1, KeyPair.ALG_RSA_CRT, KeyBuilder.LENGTH_RSA_4096, maxMsgLen);
+
+        // Test with mLen < k - 11
+        testSelftRSA(Cipher.ALG_RSA_PKCS1, KeyPair.ALG_RSA_CRT, KeyBuilder.LENGTH_RSA_4096, (short) (maxMsgLen - 1));
+
+        // Test with mLen > k - 11
+        try{
+            testSelftRSA(Cipher.ALG_RSA_PKCS1, KeyPair.ALG_RSA_CRT, KeyBuilder.LENGTH_RSA_4096, (short) (maxMsgLen + 1));
+            assert(false);
+        }
+        catch (CryptoException ex) {
+            assertEquals(CryptoException.ILLEGAL_USE, ex.getReason());
+        }
+    }
+
+    public void testSelftRSA_PKCS1_OEAP(){
+        // Refer to https://www.rfc-editor.org/rfc/rfc8017#section-7.1.1
+        // mLen <= k - 2hLen - 2,
+        //      k is the length in octets of the modulus n and
+        //      hLen is the hash function output octet length, SHA1 is used as default https://www.rfc-editor.org/rfc/rfc8017#appendix-A.2.1
+        short hLen = 20; // SHA1 hash size is 20 bytes
+
+       // Test at maximum message length, mLen = k - 2hLen - 2
+        // RSA Key Pair
+        short k = KeyBuilder.LENGTH_RSA_512/Byte.SIZE;
+        short maxMsgLen = (short) (k - (2*hLen) - 2);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1_OAEP, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_512, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_736/Byte.SIZE;
+        maxMsgLen = (short) (k - (2*hLen) - 2);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1_OAEP, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_736, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_768/Byte.SIZE;
+        maxMsgLen = (short) (k - (2*hLen) - 2);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1_OAEP, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_768, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_896/Byte.SIZE;
+        maxMsgLen = (short) (k - (2*hLen) - 2);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1_OAEP, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_896, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_1024/Byte.SIZE;
+        maxMsgLen = (short) (k - (2*hLen) - 2);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1_OAEP, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_1024, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_1280/Byte.SIZE;
+        maxMsgLen = (short) (k - (2*hLen) - 2);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1_OAEP, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_1280, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_1536/Byte.SIZE;
+        maxMsgLen = (short) (k - (2*hLen) - 2);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1_OAEP, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_1536, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_1984/Byte.SIZE;
+        maxMsgLen = (short) (k - (2*hLen) - 2);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1_OAEP, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_1984, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_2048/Byte.SIZE;
+        maxMsgLen = (short) (k - (2*hLen) - 2);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1_OAEP, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_2048, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_3072/Byte.SIZE;
+        maxMsgLen = (short) (k - (2*hLen) - 2);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1_OAEP, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_3072, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_4096/Byte.SIZE;
+        maxMsgLen = (short) (k - (2*hLen) - 2);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1_OAEP, KeyPair.ALG_RSA, KeyBuilder.LENGTH_RSA_4096, maxMsgLen);
+
+        // RSA Key Pair with private key in its Chinese Remainder Theorem form
+        k = KeyBuilder.LENGTH_RSA_512/Byte.SIZE;
+        maxMsgLen = (short) (k - (2*hLen) - 2);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1_OAEP, KeyPair.ALG_RSA_CRT, KeyBuilder.LENGTH_RSA_512, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_736/Byte.SIZE;
+        maxMsgLen = (short) (k - (2*hLen) - 2);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1_OAEP, KeyPair.ALG_RSA_CRT, KeyBuilder.LENGTH_RSA_736, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_768/Byte.SIZE;
+        maxMsgLen = (short) (k - (2*hLen) - 2);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1_OAEP, KeyPair.ALG_RSA_CRT, KeyBuilder.LENGTH_RSA_768, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_896/Byte.SIZE;
+        maxMsgLen = (short) (k - (2*hLen) - 2);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1_OAEP, KeyPair.ALG_RSA_CRT, KeyBuilder.LENGTH_RSA_896, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_1024/Byte.SIZE;
+        maxMsgLen = (short) (k - (2*hLen) - 2);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1_OAEP, KeyPair.ALG_RSA_CRT, KeyBuilder.LENGTH_RSA_1024, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_1280/Byte.SIZE;
+        maxMsgLen = (short) (k - (2*hLen) - 2);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1_OAEP, KeyPair.ALG_RSA_CRT, KeyBuilder.LENGTH_RSA_1280, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_1536/Byte.SIZE;
+        maxMsgLen = (short) (k - (2*hLen) - 2);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1_OAEP, KeyPair.ALG_RSA_CRT, KeyBuilder.LENGTH_RSA_1536, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_1984/Byte.SIZE;
+        maxMsgLen = (short) (k - (2*hLen) - 2);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1_OAEP, KeyPair.ALG_RSA_CRT, KeyBuilder.LENGTH_RSA_1984, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_2048/Byte.SIZE;
+        maxMsgLen = (short) (k - (2*hLen) - 2);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1_OAEP, KeyPair.ALG_RSA_CRT, KeyBuilder.LENGTH_RSA_2048, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_3072/Byte.SIZE;
+        maxMsgLen = (short) (k - (2*hLen) - 2);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1_OAEP, KeyPair.ALG_RSA_CRT, KeyBuilder.LENGTH_RSA_3072, maxMsgLen);
+
+        k = KeyBuilder.LENGTH_RSA_4096/Byte.SIZE;
+        maxMsgLen = (short) (k - (2*hLen) - 2);
+        testSelftRSA(Cipher.ALG_RSA_PKCS1_OAEP, KeyPair.ALG_RSA_CRT, KeyBuilder.LENGTH_RSA_4096, maxMsgLen);
+
+        // Test with mLen < k - 2hLen - 2
+        testSelftRSA(Cipher.ALG_RSA_PKCS1_OAEP, KeyPair.ALG_RSA_CRT, KeyBuilder.LENGTH_RSA_4096, (short) (maxMsgLen - 1));
+
+        // Test with mLen > k - 2hLen - 2
+        try{
+            testSelftRSA(Cipher.ALG_RSA_PKCS1_OAEP, KeyPair.ALG_RSA_CRT, KeyBuilder.LENGTH_RSA_4096, (short) (maxMsgLen + 1));
+            assert(false);
+        }
+        catch (CryptoException ex) {
+            assertEquals(CryptoException.ILLEGAL_USE, ex.getReason());
+        }
+    }
+
+    private void testSelftRSA(byte algorithm, byte keyPairAlgorithm, short keySizeInBits, short messageLen) {
+        Cipher cipher = Cipher.getInstance(algorithm, false);
+        KeyPair kp = new KeyPair(keyPairAlgorithm, keySizeInBits);
         kp.genKeyPair();
 
         cipher.init(kp.getPublic(), Cipher.MODE_ENCRYPT);
-        byte[] msg = new byte[127];
-        byte[] encryptedMsg = new byte[128];
-        RandomData rnd = RandomData.getInstance(RandomData.ALG_PSEUDO_RANDOM);
-        rnd.generateData(msg, (short) 0, (short) msg.length);
+
+        short keySizeInBytes = (short) (keySizeInBits/Byte.SIZE);
+        byte[] msg = new byte[messageLen];
+        byte[] encryptedMsg = new byte[keySizeInBytes];
+        new Random().nextBytes(msg);
+
         cipher.doFinal(msg, (short) 0, (short) msg.length, encryptedMsg, (short) 0);
 
         cipher.init(kp.getPrivate(), Cipher.MODE_DECRYPT);


### PR DESCRIPTION
ApduExtendedCasesApplet was created to test

- Case 2 with Le = 0x00 
- Case 2E with 3-byte Le
- Case 3E with 3-byte Lc
- Case 4 with Le = 0x00
- Case 4E with 3-byte Lc and 2-byte Le 

Reference - https://docs.oracle.com/en/java/javacard/3.1/guide/extended-apdu-format.html#GUID-0F452782-9402-43E9-B39C-337772C200DF

To verify that jCardSim Simulator runtime is complied with ISO7816-4 and check issue #189