### PR TITLE
Replaced Bintray with GH packages in DistributionManagment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,9 +44,9 @@
     
     <distributionManagement>
         <repository>
-            <id>bintray-jcardsim-maven-jCardSim</id>
-            <name>jcardsim-maven-jCardSim</name>
-            <url>https://api.bintray.com/maven/jcardsim/maven/jCardSim</url>
+            <id>github</id>
+            <name>GitHub Licel JCardSim Apache Maven Packages</name>
+            <url>https://maven.pkg.github.com/licel/jcardsim</url>
         </repository>
     </distributionManagement>    
 


### PR DESCRIPTION
Bintray package repository is not working anymore, moving to GH packages.