### PR TITLE
Fixed resetRuntime cause exception

### DIFF
--- a/src/main/java/com/licel/jcardsim/base/PersistentSimulatorRuntime.java
+++ b/src/main/java/com/licel/jcardsim/base/PersistentSimulatorRuntime.java
@@ -33,7 +33,6 @@ import java.util.Arrays;
 import java.util.Iterator;
 import javacard.framework.AID;
 import javacard.framework.Applet;
-import javacard.framework.JCSystem;
 import javacard.framework.SystemException;
 import org.objenesis.strategy.StdInstantiatorStrategy;
 
@@ -50,7 +49,11 @@ public class PersistentSimulatorRuntime extends SimulatorRuntime {
         kryo.setInstantiatorStrategy(new StdInstantiatorStrategy());
         
         String baseDir = System.getProperties().getProperty(PERSISTENT_BASE_DIR, null);
-        if(baseDir != null) {
+
+        if( (baseDir != null) ) {
+            if( isEmptyOrConsecutiveSpaces(baseDir) )
+                throw new RuntimeException("persistentSimulatorRuntime.dir is invalid");
+
             Path p = Paths.get(baseDir, System.getProperty(ATR_SYSTEM_PROPERTY, DEFAULT_ATR));
             File appletsDirFile = p.toFile();
             if(!appletsDirFile.exists()) {
@@ -216,5 +219,14 @@ public class PersistentSimulatorRuntime extends SimulatorRuntime {
             AID aid = appInst.getAID();
             updateAppletFile(aid, applet);
         }
+    }
+
+    private boolean isEmptyOrConsecutiveSpaces(String baseDir){
+        for( char ch : baseDir.toCharArray()){
+            if( ch != ' '){
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/src/main/java/com/licel/jcardsim/base/PersistentSimulatorRuntime.java
+++ b/src/main/java/com/licel/jcardsim/base/PersistentSimulatorRuntime.java
@@ -51,7 +51,7 @@ public class PersistentSimulatorRuntime extends SimulatorRuntime {
         String baseDir = System.getProperties().getProperty(PERSISTENT_BASE_DIR, null);
 
         if( (baseDir != null) ) {
-            if( isEmptyOrConsecutiveSpaces(baseDir) )
+            if( baseDir.trim().isEmpty() )
                 throw new RuntimeException("persistentSimulatorRuntime.dir is invalid");
 
             Path p = Paths.get(baseDir, System.getProperty(ATR_SYSTEM_PROPERTY, DEFAULT_ATR));
@@ -219,14 +219,5 @@ public class PersistentSimulatorRuntime extends SimulatorRuntime {
             AID aid = appInst.getAID();
             updateAppletFile(aid, applet);
         }
-    }
-
-    private boolean isEmptyOrConsecutiveSpaces(String baseDir){
-        for( char ch : baseDir.toCharArray()){
-            if( ch != ' '){
-                return false;
-            }
-        }
-        return true;
     }
 }

--- a/src/main/java/com/licel/jcardsim/base/PersistentSimulatorRuntime.java
+++ b/src/main/java/com/licel/jcardsim/base/PersistentSimulatorRuntime.java
@@ -119,8 +119,11 @@ public class PersistentSimulatorRuntime extends SimulatorRuntime {
     public void resetRuntime() {
         activateSimulatorRuntimeInstance();
         transientMemory.clearOnReset();
-        updateAppletFiles();
-        
+
+        if(appletsDir != null) {
+            updateAppletFiles();
+        }
+
         Iterator<AID> aids = applets.keySet().iterator();
         ArrayList<AID> aidsToTrash = new ArrayList<AID>();
         while (aids.hasNext()) {

--- a/src/main/java/com/licel/jcardsim/base/PersistentSimulatorRuntime.java
+++ b/src/main/java/com/licel/jcardsim/base/PersistentSimulatorRuntime.java
@@ -52,7 +52,7 @@ public class PersistentSimulatorRuntime extends SimulatorRuntime {
 
         if( (baseDir != null) ) {
             if( baseDir.trim().isEmpty() )
-                throw new RuntimeException("persistentSimulatorRuntime.dir is invalid");
+                throw new RuntimeException("persistentSimulatorRuntime.dir can't be empty string");
 
             Path p = Paths.get(baseDir, System.getProperty(ATR_SYSTEM_PROPERTY, DEFAULT_ATR));
             File appletsDirFile = p.toFile();

--- a/src/test/java/com/licel/jcardsim/base/PersistentRuntimeTest.java
+++ b/src/test/java/com/licel/jcardsim/base/PersistentRuntimeTest.java
@@ -225,7 +225,7 @@ public class PersistentRuntimeTest extends TestCase {
         try {
             SimulatorRuntime runtime = new PersistentSimulatorRuntime();
         }catch(Throwable ex){
-            assertEquals(ex.getMessage(),"persistentSimulatorRuntime.dir is invalid");
+            assertEquals(ex.getMessage(),"persistentSimulatorRuntime.dir can't be empty string");
         }
 
         // Check path must not be created
@@ -242,7 +242,7 @@ public class PersistentRuntimeTest extends TestCase {
         try {
             SimulatorRuntime runtime = new PersistentSimulatorRuntime();
         }catch(Throwable ex){
-            assertEquals(ex.getMessage(),"persistentSimulatorRuntime.dir is invalid");
+            assertEquals(ex.getMessage(),"persistentSimulatorRuntime.dir can't be empty string");
         }
 
         // Check path must not be created
@@ -259,7 +259,7 @@ public class PersistentRuntimeTest extends TestCase {
         try {
             SimulatorRuntime runtime = new PersistentSimulatorRuntime();
         }catch(Throwable ex){
-            assertEquals(ex.getMessage(),"persistentSimulatorRuntime.dir is invalid");
+            assertEquals(ex.getMessage(),"persistentSimulatorRuntime.dir can't be empty string");
         }
 
         // Check path must not be created

--- a/src/test/java/com/licel/jcardsim/base/PersistentRuntimeTest.java
+++ b/src/test/java/com/licel/jcardsim/base/PersistentRuntimeTest.java
@@ -17,6 +17,8 @@ package com.licel.jcardsim.base;
 
 import static com.licel.jcardsim.base.Simulator.ATR_SYSTEM_PROPERTY;
 import static com.licel.jcardsim.base.Simulator.DEFAULT_ATR;
+
+import com.licel.jcardsim.samples.HelloWorldApplet;
 import com.licel.jcardsim.samples.PersistentApplet;
 import com.licel.jcardsim.utils.AIDUtil;
 import com.licel.jcardsim.utils.ByteUtil;
@@ -39,7 +41,7 @@ public class PersistentRuntimeTest extends TestCase {
     String aidStr;
     AID aid;
     Path baseDir;
-    
+
     public PersistentRuntimeTest(String testName) {
         super(testName);
     }
@@ -62,7 +64,7 @@ public class PersistentRuntimeTest extends TestCase {
 
     public void testInstallApplet() {
         System.out.println("testInstallApplet");
-        
+
         SimulatorRuntime runtime = new PersistentSimulatorRuntime();
         Simulator instance = new Simulator(runtime);
 
@@ -105,7 +107,7 @@ public class PersistentRuntimeTest extends TestCase {
     
     public void testDeSelectApplet() {
         System.out.println("testDeSelectApplet");
-        
+
         AID otherAid = AIDUtil.create("FFFFFFFFFF0F070809");
         SimulatorRuntime runtime = new PersistentSimulatorRuntime();
         Simulator instance = new Simulator(runtime);
@@ -133,7 +135,7 @@ public class PersistentRuntimeTest extends TestCase {
     
     public void testNullAppletDir() {
         System.out.println("testNullAppletDir");
-       
+
         System.clearProperty("persistentSimulatorRuntime.dir");
         SimulatorRuntime runtime = new PersistentSimulatorRuntime();
         Simulator instance = new Simulator(runtime);
@@ -152,7 +154,7 @@ public class PersistentRuntimeTest extends TestCase {
         assertEquals(true, instance.selectApplet(aid));
         byte[] response = instance.transmitCommand(new byte[]{0x01, GET_DATA_INS, 0x00, 0x00});
         assertSW_9000(response);
-        
+
         SimulatorRuntime otherRuntime = new PersistentSimulatorRuntime();
         Simulator otherInstance = new Simulator(otherRuntime);
         otherInstance.loadApplet(aid, PersistentApplet.class);
@@ -192,5 +194,26 @@ public class PersistentRuntimeTest extends TestCase {
             }
         }
         return directoryToBeDeleted.delete();
+    }
+
+    public void testResetRuntime(){
+        System.out.println("testResetRuntime");
+
+        System.clearProperty("persistentSimulatorRuntime.dir");
+
+        SimulatorRuntime runtime = new PersistentSimulatorRuntime();
+        Simulator instance = new Simulator(runtime);
+        instance.installApplet(aid, PersistentApplet.class);
+        assertEquals(true, instance.selectApplet(aid));
+        byte[] response = instance.transmitCommand(new byte[]{0x01, GET_DATA_INS, 0x00, 0x00});
+        assertSW_9000(response);
+
+        Simulator otherInstance = new Simulator(runtime);
+        AID helloWorldAppletAID = AIDUtil.create("01020304050607080A");
+        otherInstance.installApplet(helloWorldAppletAID, HelloWorldApplet.class);
+        assertEquals(true, otherInstance.selectApplet(helloWorldAppletAID));
+        byte[] otherResponse = otherInstance.transmitCommand(new byte[]{0x01, 0x02, 0x00, 0x00});
+        assertSW_9000(otherResponse);
+
     }
 }

--- a/src/test/java/com/licel/jcardsim/base/PersistentRuntimeTest.java
+++ b/src/test/java/com/licel/jcardsim/base/PersistentRuntimeTest.java
@@ -216,4 +216,55 @@ public class PersistentRuntimeTest extends TestCase {
         assertSW_9000(otherResponse);
 
     }
+
+    public void testEmptyAppletDir() {
+        System.out.println("testEmptyAppletDir");
+
+        System.setProperty("persistentSimulatorRuntime.dir","");
+
+        try {
+            SimulatorRuntime runtime = new PersistentSimulatorRuntime();
+        }catch(Throwable ex){
+            assertEquals(ex.getMessage(),"persistentSimulatorRuntime.dir is invalid");
+        }
+
+        // Check path must not be created
+        Path path = Paths.get(DEFAULT_ATR);
+        assertEquals(false, Files.exists(path));
+    }
+
+    public void testSpaceAppletDir() {
+        System.out.println("testEmptyAppletDir");
+
+        String spacePathStr = " ";
+        System.setProperty("persistentSimulatorRuntime.dir",spacePathStr);
+
+        try {
+            SimulatorRuntime runtime = new PersistentSimulatorRuntime();
+        }catch(Throwable ex){
+            assertEquals(ex.getMessage(),"persistentSimulatorRuntime.dir is invalid");
+        }
+
+        // Check path must not be created
+        Path path = Paths.get(spacePathStr);
+        assertEquals(false, Files.exists(path));
+    }
+
+    public void testConsecutiveSpaceAppletDir() {
+        System.out.println("testEmptyAppletDir");
+
+        String consecutiveSpacePathStr = "    ";
+        System.setProperty("persistentSimulatorRuntime.dir",consecutiveSpacePathStr);
+
+        try {
+            SimulatorRuntime runtime = new PersistentSimulatorRuntime();
+        }catch(Throwable ex){
+            assertEquals(ex.getMessage(),"persistentSimulatorRuntime.dir is invalid");
+        }
+
+        // Check path must not be created
+        Path path = Paths.get(consecutiveSpacePathStr);
+        assertEquals(false, Files.exists(path));
+
+    }
 }


### PR DESCRIPTION
- Fixed resetRuntime cause exception when PersistentSimulatorRuntime instance is reused to create other simulator instance if "persistentSimulatorRuntime.dir"  property is not set
- Check if persistentSimulatorRuntime.dir is either empty, single or whole consecutive space of then throw exception
