### PR TITLE
fix(BixVReader): infinite exception loop

### DIFF
--- a/src/main/java/com/licel/jcardsim/crypto/ByteContainer.java
+++ b/src/main/java/com/licel/jcardsim/crypto/ByteContainer.java
@@ -132,7 +132,7 @@ public final class ByteContainer {
         if (length == 0) {
             CryptoException.throwIt(CryptoException.UNINITIALIZED_KEY);
         }
-        return new BigInteger(1, data);
+        return new BigInteger(1, data, 0, length);
     }
 
     /**

--- a/src/main/java/com/licel/jcardsim/remote/BixVReaderCard.java
+++ b/src/main/java/com/licel/jcardsim/remote/BixVReaderCard.java
@@ -17,6 +17,8 @@ package com.licel.jcardsim.remote;
 
 import com.licel.jcardsim.base.CardManager;
 import com.licel.jcardsim.base.Simulator;
+
+import java.io.EOFException;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.security.InvalidParameterException;
@@ -135,6 +137,7 @@ public class BixVReaderCard {
 
         @Override
         public void run() {
+            int exceptionCount = 0;
             while (isRunning) {
                 try {
                     int cmd = driverProtocol.readCommand();
@@ -149,8 +152,14 @@ public class BixVReaderCard {
                             driverProtocol.writeData(CardManager.dispatchApdu(sim, apdu));
                             break;
                     }
+                } catch (EOFException eof) {
+                    eof.printStackTrace(System.err);
+                    break;
                 } catch (Exception e) {
                     e.printStackTrace(System.err);
+                    if (exceptionCount++ >= 3) {
+                        break;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes infinite loop of:

```
java.io.EOFException
        at java.base/java.io.RandomAccessFile.readFully(RandomAccessFile.java:472)
        at java.base/java.io.RandomAccessFile.readFully(RandomAccessFile.java:446)
        at com.licel.jcardsim.remote.BixVReaderIPCProtocol.readCommand(BixVReaderIPCProtocol.java:46)
        at com.licel.jcardsim.remote.BixVReaderCard$IOThread.run(BixVReaderCard.java:143)
```