### PR TITLE
ByteContainer.setBytes: fix arraycopy length discrepancy

### DIFF
--- a/src/main/java/com/licel/jcardsim/crypto/ByteContainer.java
+++ b/src/main/java/com/licel/jcardsim/crypto/ByteContainer.java
@@ -106,7 +106,7 @@ public final class ByteContainer {
      * @param length length of data in byte array
      */
     public void setBytes(byte[] buff, short offset, short length) {
-        if (data == null) {
+        if (data == null || (short) data.length != length) {
             switch (memoryType) {
                 case JCSystem.MEMORY_TYPE_TRANSIENT_DESELECT:
                     data = JCSystem.makeTransientByteArray(length, JCSystem.CLEAR_ON_DESELECT);
@@ -121,7 +121,7 @@ public final class ByteContainer {
         }
         Util.arrayCopy(buff, offset, data, (short) 0, length);
         // current length
-        this.length = length;
+        this.length = (short) data.length;
     }
 
     /**


### PR DESCRIPTION
if length < data.length, the byte should be cleared and the new values
should be right-adjusted. Otherwise, the container no longer represents
the bytearray/BigInteger correctly.

See https://github.com/licel/jcardsim/issues/209
